### PR TITLE
feat: MySQL 기본 설정 Student 기본 Entity 생성

### DIFF
--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -1,4 +1,43 @@
 package com.team.buddyya.student.domain;
 
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.PROTECTED;
+
+@Table(name = "student")
+@NoArgsConstructor(access = PROTECTED)
+@Entity
 public class Student {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(length = 64, nullable = false)
+    private String name;
+
+    @Column(length = 64, nullable = false)
+    private String major;
+
+    @Column(length = 64, nullable = false)
+    private String country;
+
+    @Column(nullable = false)
+    private Boolean certificated;
+
+    @Column(nullable = false)
+    private Boolean korean;
+
+
+    public Student(String name, String major, String country, Boolean certificated, Boolean korean) {
+        this.name = name;
+        this.major = major;
+        this.country = country;
+        this.certificated = certificated;
+        this.korean = korean;
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=buddyya
+spring.datasource.url=jdbc:mysql://localhost:3306/buddy_ya
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## 📌 관련 이슈
[이메일 인증 api 개발](https://github.com/buddy-ya/be/issues/1) #1
<br><br>

## 🛠️ 작업 내용
- MySQL 데이터베이스 초기 설정
- 공용으로 사용하기 위한 Student 기본 Entity 생성
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크
https://github.com/buddy-ya/be/pull/5/files/f3ccb4b5d17991142bd1f7785d3fecb42424e398
<br><br>
