### PR TITLE
feat: 인증 및 인가 처리를 위한 Security 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/team/buddyya/auth/domain/AuthToken.java
+++ b/src/main/java/com/team/buddyya/auth/domain/AuthToken.java
@@ -22,7 +22,7 @@ public class AuthToken {
     @Column(nullable = false)
     private String refreshToken;
 
-    @OneToOne(fetch = LAZY)
+    @OneToOne
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
 

--- a/src/main/java/com/team/buddyya/auth/domain/AuthToken.java
+++ b/src/main/java/com/team/buddyya/auth/domain/AuthToken.java
@@ -1,4 +1,38 @@
 package com.team.buddyya.auth.domain;
 
+import com.team.buddyya.student.domain.Student;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "auth_token")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
 public class AuthToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @Builder
+    public AuthToken(String refreshToken, Student student) {
+        this.refreshToken = refreshToken;
+        this.student = student;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/team/buddyya/auth/domain/CustomUserDetails.java
+++ b/src/main/java/com/team/buddyya/auth/domain/CustomUserDetails.java
@@ -1,8 +1,6 @@
 package com.team.buddyya.auth.domain;
 
-import com.team.buddyya.auth.dto.LoginStudentInfo;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,16 +15,16 @@ public class CustomUserDetails implements UserDetails {
 
     private static final String ROLE_PREFIX = "ROLE_";
 
-    private final LoginStudentInfo user;
+    private final StudentInfo studentInfo;
 
-    public CustomUserDetails(LoginStudentInfo user) {
-        this.user = user;
+    public CustomUserDetails(StudentInfo studentInfo) {
+        this.studentInfo = studentInfo;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         List<String> roles = new ArrayList<>();
-        roles.add(ROLE_PREFIX + user.role());
+        roles.add(ROLE_PREFIX + studentInfo.role());
         return roles.stream()
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());

--- a/src/main/java/com/team/buddyya/auth/domain/CustomUserDetails.java
+++ b/src/main/java/com/team/buddyya/auth/domain/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package com.team.buddyya.auth.domain;
+
+import com.team.buddyya.auth.dto.LoginStudentInfo;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    private final LoginStudentInfo user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add(ROLE_PREFIX + user.role());
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/domain/CustomUserDetails.java
+++ b/src/main/java/com/team/buddyya/auth/domain/CustomUserDetails.java
@@ -13,12 +13,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
     private static final String ROLE_PREFIX = "ROLE_";
 
     private final LoginStudentInfo user;
+
+    public CustomUserDetails(LoginStudentInfo user) {
+        this.user = user;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/team/buddyya/auth/domain/StudentInfo.java
+++ b/src/main/java/com/team/buddyya/auth/domain/StudentInfo.java
@@ -5,15 +5,15 @@ import com.team.buddyya.student.domain.Student;
 
 public record StudentInfo(
         Long id,
-        String name,
-        Role role
+        Role role,
+        Boolean isKorean
 ) {
 
     public static StudentInfo from(Student student) {
         return new StudentInfo(
                 student.getId(),
-                student.getName(),
-                student.getRole()
+                student.getRole(),
+                student.getIsKorean()
         );
     }
 }

--- a/src/main/java/com/team/buddyya/auth/domain/StudentInfo.java
+++ b/src/main/java/com/team/buddyya/auth/domain/StudentInfo.java
@@ -1,16 +1,16 @@
-package com.team.buddyya.auth.dto;
+package com.team.buddyya.auth.domain;
 
 import com.team.buddyya.student.domain.Role;
 import com.team.buddyya.student.domain.Student;
 
-public record LoginStudentInfo(
+public record StudentInfo(
         Long id,
         String name,
         Role role
 ) {
 
-    public static LoginStudentInfo from(Student student) {
-        return new LoginStudentInfo(
+    public static StudentInfo from(Student student) {
+        return new StudentInfo(
                 student.getId(),
                 student.getName(),
                 student.getRole()

--- a/src/main/java/com/team/buddyya/auth/dto/LoginStudentInfo.java
+++ b/src/main/java/com/team/buddyya/auth/dto/LoginStudentInfo.java
@@ -1,0 +1,19 @@
+package com.team.buddyya.auth.dto;
+
+import com.team.buddyya.student.domain.Role;
+import com.team.buddyya.student.domain.Student;
+
+public record LoginStudentInfo(
+        Long id,
+        String name,
+        Role role
+) {
+
+    public static LoginStudentInfo from(Student student) {
+        return new LoginStudentInfo(
+                student.getId(),
+                student.getName(),
+                student.getRole()
+        );
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/dto/request/TokenInfoRequest.java
+++ b/src/main/java/com/team/buddyya/auth/dto/request/TokenInfoRequest.java
@@ -1,0 +1,4 @@
+package com.team.buddyya.auth.dto.request;
+
+public record TokenInfoRequest(Long studentId) {
+}

--- a/src/main/java/com/team/buddyya/auth/exception/AuthException.java
+++ b/src/main/java/com/team/buddyya/auth/exception/AuthException.java
@@ -1,0 +1,18 @@
+package com.team.buddyya.auth.exception;
+
+import com.team.buddyya.common.exception.BaseException;
+import com.team.buddyya.common.exception.BaseExceptionType;
+
+public class AuthException extends BaseException {
+
+    private final AuthExceptionType authExceptionType;
+
+    public AuthException(final AuthExceptionType authExceptionType) {
+        this.authExceptionType = authExceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return authExceptionType;
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/exception/AuthExceptionType.java
+++ b/src/main/java/com/team/buddyya/auth/exception/AuthExceptionType.java
@@ -1,0 +1,42 @@
+package com.team.buddyya.auth.exception;
+
+import com.team.buddyya.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum AuthExceptionType implements BaseExceptionType {
+
+    INVALID_TOKEN(300, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    UNSUPPORTED_TOKEN(300, HttpStatus.BAD_REQUEST, "지원되지 않는 토큰입니다."),
+    EMPTY_CLAIMS(300, HttpStatus.BAD_REQUEST, "빈 토큰값입니다."),
+    ACCESS_DENIED(300, HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    UNAUTHORIZED_USER(301, HttpStatus.UNAUTHORIZED, "인가되지 않은 사용자입니다."),
+    EXPIRED_TOKEN(302, HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    INVALID_MEMBER_ID(303, HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 ID 타입입니다."),
+    EXPIRED_REFRESH_TOKEN(304, HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(305, HttpStatus.NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다.");
+
+    private final int errorCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    AuthExceptionType(int errorCode, HttpStatus httpStatus, String errorMessage) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public int errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/jwt/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.team.buddyya.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.buddyya.auth.exception.AuthExceptionType;
+import com.team.buddyya.common.exception.ExceptionResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.info("AccessDeniedHandler called: " + accessDeniedException.getMessage());
+        AuthExceptionType exceptionType = AuthExceptionType.UNAUTHORIZED_USER;
+        response.setStatus(exceptionType.httpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(new ExceptionResponse(exceptionType.errorCode(), exceptionType.errorMessage())));
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.team.buddyya.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.buddyya.auth.exception.AuthExceptionType;
+import com.team.buddyya.common.exception.ExceptionResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.info("AuthenticationEntryPoint called: " + authException.getMessage());
+        AuthExceptionType exceptionType = AuthExceptionType.ACCESS_DENIED;
+        response.setStatus(exceptionType.httpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(new ExceptionResponse(exceptionType.errorCode(), exceptionType.errorMessage())));
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/JwtAuthFilter.java
@@ -49,6 +49,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             log.info("Security Context에 '{}' 인증 정보를 저장했습니다.", authenticationToken.getName());
+            return;
         }
+        log.warn("유효하지 않은 사용자 정보입니다.");
     }
 }

--- a/src/main/java/com/team/buddyya/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/JwtAuthFilter.java
@@ -49,8 +49,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             log.info("Security Context에 '{}' 인증 정보를 저장했습니다.", authenticationToken.getName());
-            return;
         }
-        log.warn("유효하지 않은 사용자 정보입니다.");
     }
 }

--- a/src/main/java/com/team/buddyya/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/JwtAuthFilter.java
@@ -1,0 +1,56 @@
+package com.team.buddyya.auth.jwt;
+
+import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.auth.service.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtils jwtUtils;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null && jwtUtils.validateToken(token)) {
+            setAuthentication(token);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+        if (authorizationHeader != null && authorizationHeader.startsWith(BEARER_PREFIX)) {
+            return authorizationHeader.substring(7);
+        }
+        return null;
+    }
+
+    private void setAuthentication(String token) {
+        Long id = jwtUtils.getUserId(token);
+        CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(id.toString());
+        if (userDetails != null) {
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+            log.info("Security Context에 '{}' 인증 정보를 저장했습니다.", authenticationToken.getName());
+            return;
+        }
+        log.warn("유효하지 않은 사용자 정보입니다.");
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/JwtExceptionFilter.java
@@ -1,0 +1,35 @@
+package com.team.buddyya.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.buddyya.auth.exception.AuthException;
+import com.team.buddyya.common.exception.ExceptionResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AuthException ex) {
+            response.setStatus(ex.exceptionType().httpStatus().value());
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter()
+                    .write(objectMapper.writeValueAsString(new ExceptionResponse(ex.exceptionType().errorCode(), ex.exceptionType().errorMessage())));
+        }
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/jwt/JwtUtils.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/JwtUtils.java
@@ -1,0 +1,87 @@
+package com.team.buddyya.auth.jwt;
+
+import com.team.buddyya.auth.dto.request.TokenInfoRequest;
+import com.team.buddyya.auth.exception.AuthException;
+import com.team.buddyya.auth.exception.AuthExceptionType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtils {
+
+    private final Key key;
+    private final long accessTokenExpireTime;
+    private final long refreshTokenExpireTime;
+
+    public JwtUtils(@Value("${auth.jwt.secret}") String secretKey,
+                    @Value("${auth.jwt.access.expiration}") long accessTokenExpireTime,
+                    @Value("${auth.jwt.refresh.expiration}") long refreshTokenExpireTime
+    ) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpireTime = accessTokenExpireTime;
+        this.refreshTokenExpireTime = refreshTokenExpireTime;
+    }
+
+    public String createAccessToken(TokenInfoRequest context) {
+        return createToken(context, accessTokenExpireTime);
+    }
+
+    public String createRefreshToken(TokenInfoRequest context) {
+        return createToken(context, refreshTokenExpireTime);
+    }
+
+    private String createToken(TokenInfoRequest context, long expiredTime) {
+        Claims claims = Jwts.claims();
+        claims.put("studentId", context.studentId());
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(expiredTime);
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(tokenValidity.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthExceptionType.EXPIRED_TOKEN);
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            throw new AuthException(AuthExceptionType.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthExceptionType.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new AuthException(AuthExceptionType.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new AuthException(AuthExceptionType.EMPTY_CLAIMS);
+        }
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = parseClaims(token);
+        Object studentId = claims.get("studentId");
+        if (studentId instanceof Number) {
+            return ((Number) studentId).longValue();
+        }
+        throw new AuthException(AuthExceptionType.INVALID_MEMBER_ID);
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/repository/AuthTokenRepository.java
+++ b/src/main/java/com/team/buddyya/auth/repository/AuthTokenRepository.java
@@ -1,0 +1,11 @@
+package com.team.buddyya.auth.repository;
+
+import com.team.buddyya.auth.domain.AuthToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AuthTokenRepository extends JpaRepository<AuthToken, Long> {
+
+    Optional<AuthToken> findByStudentId(Long studentId);
+}

--- a/src/main/java/com/team/buddyya/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/team/buddyya/auth/service/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.team.buddyya.auth.service;
 
 import com.team.buddyya.auth.domain.CustomUserDetails;
-import com.team.buddyya.auth.dto.LoginStudentInfo;
+import com.team.buddyya.auth.domain.StudentInfo;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.exception.OnBoardingException;
 import com.team.buddyya.student.exception.OnBoardingExceptionType;
@@ -23,7 +23,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     public CustomUserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
         Student student = studentRepository.findById(Long.parseLong(id))
                 .orElseThrow(() -> new OnBoardingException(OnBoardingExceptionType.STUDENT_NOT_FOUND));
-        LoginStudentInfo studentInfo = LoginStudentInfo.from(student);
+        StudentInfo studentInfo = StudentInfo.from(student);
         return new CustomUserDetails(studentInfo);
     }
 }

--- a/src/main/java/com/team/buddyya/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/team/buddyya/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.team.buddyya.auth.service;
+
+import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.auth.dto.LoginStudentInfo;
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.exception.OnBoardingException;
+import com.team.buddyya.student.exception.OnBoardingExceptionType;
+import com.team.buddyya.student.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final StudentRepository studentRepository;
+
+    @Override
+    public CustomUserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        Student student = studentRepository.findById(Long.parseLong(id))
+                .orElseThrow(() -> new OnBoardingException(OnBoardingExceptionType.STUDENT_NOT_FOUND));
+        LoginStudentInfo studentInfo = LoginStudentInfo.from(student);
+        return new CustomUserDetails(studentInfo);
+    }
+}

--- a/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
+++ b/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.team.buddyya.common.config;
+
+import com.team.buddyya.auth.jwt.*;
+import com.team.buddyya.auth.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtils jwtUtils;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final JwtExceptionFilter jwtExceptionFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS
+                ))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtils), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthFilter.class)
+                .exceptionHandling((exceptionHandling) -> exceptionHandling
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/onboarding", "/phone-auth/**",
+                                "/auth/token/reissue").permitAll()
+                        .requestMatchers("/auth/fail").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/auth/success").hasAuthority("ROLE_STUDENT")
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+}

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -76,8 +76,4 @@ public class Student {
         this.gender = gender;
         this.isCertificated = false;
     }
-
-    public void createToken(AuthToken authToken) {
-        this.authToken = authToken;
-    }
 }

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -1,5 +1,6 @@
 package com.team.buddyya.student.domain;
 
+import com.team.buddyya.auth.domain.AuthToken;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -60,6 +61,9 @@ public class Student {
     @OneToMany(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<StudentInterest> interests;
 
+    @OneToOne(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private AuthToken authToken;
+
     @Builder
     public Student(String name, String phoneNumber, String major, String country, Boolean isKorean, Role role, University university, Gender gender) {
         this.name = name;
@@ -71,5 +75,9 @@ public class Student {
         this.university = university;
         this.gender = gender;
         this.isCertificated = false;
+    }
+
+    public void createToken(AuthToken authToken) {
+        this.authToken = authToken;
     }
 }

--- a/src/main/java/com/team/buddyya/student/dto/response/OnBoardingResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/OnBoardingResponse.java
@@ -6,15 +6,19 @@ public record OnBoardingResponse(
         String name,
         String country,
         String university,
-        String major
+        String major,
+        String accessToken,
+        String refreshToken
 ) {
 
-    public static OnBoardingResponse from(Student student) {
+    public static OnBoardingResponse from(Student student, String accessToken, String refreshToken) {
         return new OnBoardingResponse(
                 student.getName(),
                 student.getCountry(),
                 student.getUniversity().getUniversityName(),
-                student.getMajor()
+                student.getMajor(),
+                accessToken,
+                refreshToken
         );
     }
 }

--- a/src/main/java/com/team/buddyya/student/exception/OnBoardingExceptionType.java
+++ b/src/main/java/com/team/buddyya/student/exception/OnBoardingExceptionType.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum OnBoardingExceptionType implements BaseExceptionType {
 
+    STUDENT_NOT_FOUND(200, HttpStatus.NOT_FOUND, "해당 학생을 찾지 못하였습니다."),
     UNIVERSITY_NOT_FOUND(200, HttpStatus.NOT_FOUND, "해당 대학을 찾지 못하였습니다."),
     LANGUAGE_NOT_FOUND(200, HttpStatus.NOT_FOUND, "해당 언어를 찾지 못하였습니다."),
     INTEREST_NOT_FOUND(200, HttpStatus.NOT_FOUND, "해당 관심사를 찾지 못하였습니다."),

--- a/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
+++ b/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
@@ -40,7 +40,6 @@ public class OnBoardingService {
                 .student(student)
                 .build();
         authTokenRepository.save(authToken);
-        student.createToken(authToken);
         return refreshToken;
     }
 }

--- a/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
+++ b/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
@@ -1,6 +1,10 @@
 package com.team.buddyya.student.service;
 
-import com.team.buddyya.student.domain.*;
+import com.team.buddyya.auth.domain.AuthToken;
+import com.team.buddyya.auth.dto.request.TokenInfoRequest;
+import com.team.buddyya.auth.jwt.JwtUtils;
+import com.team.buddyya.auth.repository.AuthTokenRepository;
+import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.dto.request.OnBoardingRequest;
 import com.team.buddyya.student.dto.response.OnBoardingResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +20,27 @@ public class OnBoardingService {
     private final AvatarService avatarService;
     private final StudentInterestService studentInterestService;
     private final StudentLanguageService studentLanguageService;
+    private final AuthTokenRepository authTokenRepository;
+    private final JwtUtils jwtUtils;
 
     public OnBoardingResponse onboard(OnBoardingRequest request) {
         Student student = studentService.createStudent(request);
+        String accessToken = jwtUtils.createAccessToken(new TokenInfoRequest(student.getId()));
+        String refreshToken = createAndSaveToken(student);
         avatarService.createAvatar(request, student);
         studentInterestService.createStudentInterests(request, student);
         studentLanguageService.createStudentLanguages(request, student);
-        return OnBoardingResponse.from(student);
+        return OnBoardingResponse.from(student, accessToken, refreshToken);
+    }
+
+    private String createAndSaveToken(Student student) {
+        String refreshToken = jwtUtils.createRefreshToken(new TokenInfoRequest(student.getId()));
+        AuthToken authToken = AuthToken.builder()
+                .refreshToken(refreshToken)
+                .student(student)
+                .build();
+        authTokenRepository.save(authToken);
+        student.createToken(authToken);
+        return refreshToken;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,8 @@ solapi.api.secret=${SOLAPI_API_SECRET}
 solapi.api.number=${SOLAPI_FROM_NUMBER}
 
 spring.profiles.active=${ACTIVE}
+
+#Jwt key & expired time
+auth.jwt.secret=vItzBpfi0YGTCB55MTBTdFgy2RsUe8ZmabUE2Ls/A3k=
+auth.jwt.access.expiration=86400
+auth.jwt.refresh.expiration=5184000


### PR DESCRIPTION
## 📌 관련 이슈
[Spring Security 설정[#6]](https://github.com/buddy-ya/be/issues/6)
<br><br>

## 🛠️ 작업 내용
- jwt를 관리하는 **JwtUtils** 추가
   - accessToken 발급 기능
   - refreshToken 발급 기능
   - 토큰 검증 기능
   - 토큰 claim 파싱 기능
   
- **학생 생성 후 accessToken, refreshToken 발급 로직** 수정

- **인증과 인가를 위한 Spring Security** 기능 도입
   -  jwtAuthFilter로 인증된 사용자 검증
   - 일반 사용자와 관리자 구분(인가 처리)

- 인증과 인가 **filter에서 발생하는 오류 직접 처리**
<br><br>

## 🎯 리뷰 포인트

### 코드 리뷰 포인트 ✅
- 코드 컨벤션이 잘 지켜졌는가?
- 예외처리가 빠진 부분은 없는가?
- 인증과 인가 처리가 제대로 되었는가?


### API의 정상 흐름🌊

Spring Security에 깊은 이해가 필요할 것 같아 설명은 PR로 부족하다고 생각합니다. 따라서 PR에는 간략하게 핵심 로직만 설명하고 대면으로 자세한 흐름에 대해서 설명 할 예정입니다!

1. **요청 수신**
   - 클라이언트가 서버로 HTTP 요청을 보냅니다

2. **필터 체인**
   - 요청은 `SecurityFilterChain`을 거쳐 여러 보안 필터를 통과합니다
   - 이 때 csrf 비활성화, jwt 토큰 인증 방식을 사용하기 때문에 세션 방식 비활성화, 폼 기반 로그인 비활성화, http Basic 인증 비활성화 설정을 하였습니다
   - `SecurityConfig` 클래스에서 필터 체인을 설정합니다

3. **JWT 인증 처리 - JwtAuthFilter**
   - 요청 헤더에서 JWT 토큰을 추출하고, 토큰이 유효한지 검증합니다
   - 토큰이 유효하면 `SecurityContextHolder`에 사용자에 대한 정보를 담고 요청을 계속 진행합니다

4. **인증되지 않은 사용자**
   - 토큰이 없거나, 유효하지 않거나, 만료된 경우 AuthException을 발생시키고 `JwtExceptionFilter`에서 오류 처리를 합니다
   - JwtExceptionFilter에서 처리하지 않은 Authorization Header가 비어있는 경우 등과 같은 오류는 CustomAuthenticationEntryPoint에서 처리를 합니다

5. **권한 확인 - 인가된 사용자**
   - 인증이 되었으면 인가 처리를 합니다
   - 인가에 대한 정보는 인증 처리에서 'SecurityContextHolder'에 저장한 상태입니다
   - 인가가 거부된 사용자(Role이 Student인데 Admin 페이지에 접근하는 사용자)는 `CustomAccessDeniedHandler`가 호출되어 인가되지 않은 사용자에 대한 처리를 합니다

7. **인가된 사용자면 요청을 수행합니다.**

### 고민했던 점 🤔

#### 1. 토큰에 어떤 정보를 넣어야 할까?
토큰에 student id 값만 넣을지 vs country, name, 성별과 같은 정보들도 같이 넣을지에 대해 고민 하다가 id 값만 넣었습니다. 이유는 다음과 같습니다.

1. token의 크기가 커질수록 **오버헤드 발생**
2. 이메일, 전화번호와 같은 **개인 정보 노출 방지**
3. **갱신되지 않은 사용자의 정보 사용 방지**
-> 사용자가 **개인정보를 수정 후**에, 수정 전 발급 받은 토큰으로 요청을 보낸 상황입니다.
이 때 token의 claim 값을 사용하게 되면 수정 전 정보를 사용하게 됩니다.
따라서 student의 id값으로 DB조회 후 student의 정보를 Security Context Holder에 저장하여 학생의 최신 정보를 가져오는 방법으로 사용했습니다.
찾아보니 ROLE까지는 token에 저장해도 괜찮다고 합니다.

#### 2. filter에서 발생한 오류처리는 어떻게 해줘야 될까?
인증 시 발생한 오류를 Exception Handler로 공통 오류 처리를 하려고 했지만 제대로 작동하지 않았습니다.

이에 대한 고민과 해결한 방법에 대한 글을 작성하였고 링크 첨부해드립니다.
[filter에서 ExceptionHandler가 동작하지 않은 이유](https://mark12345.notion.site/filter-ExceptionHandler-13e17d6854eb806d9d9ac6de09f5af4c?pvs=4)
<br><br>

## 📎 커밋 범위 링크
https://github.com/buddy-ya/be/pull/9/files
<br><br>
