### PR TITLE
feat: 토큰 만료 시 재발급 기능

### DIFF
--- a/src/main/java/com/team/buddyya/auth/controller/AuthController.java
+++ b/src/main/java/com/team/buddyya/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.team.buddyya.auth.controller;
+
+import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.auth.domain.StudentInfo;
+import com.team.buddyya.auth.dto.request.TokenReissueRequest;
+import com.team.buddyya.auth.dto.response.TokenReissueResponse;
+import com.team.buddyya.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenReissueResponse> reissueToken(@RequestBody TokenReissueRequest request) {
+        TokenReissueResponse tokenResponse = authService.reissueToken(request);
+        return ResponseEntity.ok(tokenResponse);
+    }
+}

--- a/src/main/java/com/team/buddyya/auth/controller/AuthController.java
+++ b/src/main/java/com/team/buddyya/auth/controller/AuthController.java
@@ -22,4 +22,16 @@ public class AuthController {
         TokenReissueResponse tokenResponse = authService.reissueToken(request);
         return ResponseEntity.ok(tokenResponse);
     }
+
+    @GetMapping("/success")
+    public ResponseEntity<String> success(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        StudentInfo studentInfo = userDetails.getStudentInfo();
+        return ResponseEntity.ok(studentInfo.toString());
+    }
+
+    @GetMapping("/fail")
+    public ResponseEntity<String> fail(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        StudentInfo studentInfo = userDetails.getStudentInfo();
+        return ResponseEntity.ok(studentInfo.toString());
+    }
 }

--- a/src/main/java/com/team/buddyya/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/com/team/buddyya/auth/dto/request/TokenReissueRequest.java
@@ -1,0 +1,4 @@
+package com.team.buddyya.auth.dto.request;
+
+public record TokenReissueRequest(String refreshToken) {
+}

--- a/src/main/java/com/team/buddyya/auth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/team/buddyya/auth/dto/response/TokenReissueResponse.java
@@ -1,0 +1,7 @@
+package com.team.buddyya.auth.dto.response;
+
+public record TokenReissueResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/team/buddyya/auth/exception/AuthExceptionType.java
+++ b/src/main/java/com/team/buddyya/auth/exception/AuthExceptionType.java
@@ -12,8 +12,8 @@ public enum AuthExceptionType implements BaseExceptionType {
     UNAUTHORIZED_USER(301, HttpStatus.UNAUTHORIZED, "인가되지 않은 사용자입니다."),
     EXPIRED_TOKEN(302, HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_MEMBER_ID(303, HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 ID 타입입니다."),
-    EXPIRED_REFRESH_TOKEN(304, HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
-    REFRESH_TOKEN_NOT_FOUND(305, HttpStatus.NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다.");
+    REFRESH_TOKEN_NOT_FOUND(305, HttpStatus.NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다."),
+    INVALID_REFRESH_TOKEN(305, HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/auth/service/AuthService.java
+++ b/src/main/java/com/team/buddyya/auth/service/AuthService.java
@@ -1,0 +1,61 @@
+package com.team.buddyya.auth.service;
+
+import com.team.buddyya.auth.domain.AuthToken;
+import com.team.buddyya.auth.dto.request.TokenInfoRequest;
+import com.team.buddyya.auth.dto.request.TokenReissueRequest;
+import com.team.buddyya.auth.dto.response.TokenReissueResponse;
+import com.team.buddyya.auth.exception.AuthException;
+import com.team.buddyya.auth.exception.AuthExceptionType;
+import com.team.buddyya.auth.jwt.JwtUtils;
+import com.team.buddyya.auth.repository.AuthTokenRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private static final int REFRESH_TOKEN_THRESHOLD_DAYS = 30;
+
+    private final JwtUtils jwtUtils;
+    private final AuthTokenRepository authTokenRepository;
+
+    public TokenReissueResponse reissueToken(TokenReissueRequest request) {
+        jwtUtils.validateToken(request.refreshToken());
+        Claims claims = jwtUtils.parseClaims(request.refreshToken());
+        Long studentId = claims.get("studentId", Long.class);
+        AuthToken authToken = authTokenRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new AuthException(AuthExceptionType.REFRESH_TOKEN_NOT_FOUND));
+        if(!authToken.getRefreshToken().equals(request.refreshToken())) {
+            throw new AuthException(AuthExceptionType.INVALID_REFRESH_TOKEN);
+        }
+        if (isTokenExpiringWithinDays(claims)) {
+            return reissueAccessAndRefreshToken(studentId, authToken);
+        }
+        return reissueAccessToken(studentId);
+    }
+
+    private boolean isTokenExpiringWithinDays(Claims claims) {
+        ZonedDateTime expirationDate = claims.getExpiration().toInstant().atZone(ZonedDateTime.now().getZone());
+        long daysUntilExpiration = ChronoUnit.DAYS.between(ZonedDateTime.now(), expirationDate);
+        return daysUntilExpiration <= REFRESH_TOKEN_THRESHOLD_DAYS;
+    }
+
+    private TokenReissueResponse reissueAccessAndRefreshToken(Long studentId, AuthToken authToken) {
+        String newAccessToken = jwtUtils.createAccessToken(new TokenInfoRequest(studentId));
+        String newRefreshToken = jwtUtils.createRefreshToken(new TokenInfoRequest(studentId));
+        authToken.updateRefreshToken(newRefreshToken);
+        return new TokenReissueResponse(newAccessToken, newRefreshToken);
+    }
+
+    private TokenReissueResponse reissueAccessToken(Long studentId) {
+        String newAccessToken = jwtUtils.createAccessToken(new TokenInfoRequest(studentId));
+        return new TokenReissueResponse(newAccessToken, null);
+    }
+}

--- a/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
+++ b/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                         .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/onboarding", "/phone-auth/**",
-                                "/auth/token/reissue").permitAll()
+                                "/auth/reissue").permitAll()
                         .requestMatchers("/auth/fail").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/auth/success").hasAuthority("ROLE_STUDENT")
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 📌 관련 이슈
[토큰 만료 시 재발급[#12]](https://github.com/buddy-ya/be/issues/12)
<br><br>

## 🛠️ 작업 내용
- 토큰 만료 시 재발급하는 api 추가
- 발급한 토큰을 보내 테스트하는 api 추가

<br><br>

## 🎯 리뷰 포인트

### 코드 리뷰 포인트 ✅
- 코드 컨벤션이 잘 지켜졌는가?
- 예외처리가 빠진 부분은 없는가?
- 토큰 재발급에 필요없는 부분은 없는가?

### 알아야 할 내용
accessToken 만료 시 refreshToken을 보내 재발급하는 기능입니다
**accessToken의 기간은 1일**, **refreshToken의 기간은 2달**로 정했습니다

accessToken이 만료된 경우 헤더에 refreshToken을 포함하여 auth/reissue api를 호출하여 reissueToken 메서드를 실행합니다
DB에 저장한 refreshToken과 보낸 **refreshToken이 일치하는지 확인** 후 **accessToken을 갱신**합니다
이 때 **`refreshToken의 기간이 30일보다 적게 남았다면 refreshToken도 같이 갱신`** 합니다
refreshToken의 기간이 30일보다 많이 남았다면 accessToken만 갱신해줍니다

만약 refreshToken의 기간이 만료됐으면 프론트에서 재로그인을 수행할 수 있게 **`만료된 토큰입니다`** 오류를 보냅니다


응답 형식은 다음과 같습니다.

**`refreshToken이 30일보다 적게 남았을 때`**
```
{
    "accessToken": "{accessToken}",
    "refreshToken": "{refreshToken}"
}
```
**`refreshToken이 30일보다 길게 남았을 때`**
```
{
    "accessToken": "{accessToken}",
    "refreshToken": null
}
```
발급한 토큰을 테스트하기 위한 success와 fail API도 만들었습니다
success는 **올바른 token을 header에 넣어주면 통과**하는 API입니다
fail은  **올바른 token을 header 넣어줘도 관리자 권한 API이기 때문에 인가에 실패** 하는 API입니다

카카오에서 refreshToken 갱신 예시를 참고하시면 좋을 것 같습니다
[카카오 자동로그인 RefreshToken 갱신](https://devtalk.kakao.com/t/refreshtoken/86447)
<br><br>

## 📎 커밋 범위 링크
https://github.com/buddy-ya/be/pull/14/files/53cd1794e5da7bbbb32151bd8effa8e66c59287b
<br><br>
