### PR TITLE
feat: 피드 목록 조회/상세 조회/생성/수정/삭제 API 구현

### DIFF
--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -10,6 +10,7 @@ import com.team.buddyya.feed.service.FeedService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,5 +45,13 @@ public class FeedController {
                                                          @RequestBody FeedCreateRequest request) {
         FeedCreateResponse response = feedService.createFeed(userDetails.getStudentInfo(), request);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{feedId}")
+    public ResponseEntity<Void> deleteFeed(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long feedId) {
+        feedService.deleteFeed(userDetails.getStudentInfo(), feedId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -1,7 +1,9 @@
 package com.team.buddyya.feed.controller;
 
 import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.feed.dto.request.FeedCreateRequest;
 import com.team.buddyya.feed.dto.request.FeedListRequest;
+import com.team.buddyya.feed.dto.response.FeedCreateResponse;
 import com.team.buddyya.feed.dto.response.FeedListResponse;
 import com.team.buddyya.feed.dto.response.FeedResponse;
 import com.team.buddyya.feed.service.FeedService;
@@ -11,6 +13,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,6 +36,13 @@ public class FeedController {
     public ResponseEntity<FeedResponse> getFeed(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                 @PathVariable Long feedId) {
         FeedResponse response = feedService.getFeed(userDetails.getStudentInfo(), feedId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<FeedCreateResponse> createFeed(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                         @RequestBody FeedCreateRequest request) {
+        FeedCreateResponse response = feedService.createFeed(userDetails.getStudentInfo(), request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -13,9 +13,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,7 +48,7 @@ public class FeedController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/{feedId}")
+    @PatchMapping("/{feedId}")
     public ResponseEntity<Void> updateFeed(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long feedId,

--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -3,7 +3,7 @@ package com.team.buddyya.feed.controller;
 import com.team.buddyya.auth.domain.CustomUserDetails;
 import com.team.buddyya.feed.dto.request.FeedCreateRequest;
 import com.team.buddyya.feed.dto.request.FeedListRequest;
-import com.team.buddyya.feed.dto.response.FeedCreateResponse;
+import com.team.buddyya.feed.dto.request.FeedUpdateRequest;
 import com.team.buddyya.feed.dto.response.FeedListResponse;
 import com.team.buddyya.feed.dto.response.FeedResponse;
 import com.team.buddyya.feed.service.FeedService;
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,6 +34,13 @@ public class FeedController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping
+    public ResponseEntity<Void> createFeed(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                           @RequestBody FeedCreateRequest request) {
+        feedService.createFeed(userDetails.getStudentInfo(), request);
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping("/{feedId}")
     public ResponseEntity<FeedResponse> getFeed(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                 @PathVariable Long feedId) {
@@ -40,12 +48,15 @@ public class FeedController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping
-    public ResponseEntity<FeedCreateResponse> createFeed(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                         @RequestBody FeedCreateRequest request) {
-        FeedCreateResponse response = feedService.createFeed(userDetails.getStudentInfo(), request);
-        return ResponseEntity.ok(response);
+    @PutMapping("/{feedId}")
+    public ResponseEntity<Void> updateFeed(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long feedId,
+            @RequestBody FeedUpdateRequest request) {
+        feedService.updateFeed(userDetails.getStudentInfo(), feedId, request);
+        return ResponseEntity.noContent().build();
     }
+
 
     @DeleteMapping("/{feedId}")
     public ResponseEntity<Void> deleteFeed(

--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -1,0 +1,32 @@
+package com.team.buddyya.feed.controller;
+
+import com.team.buddyya.feed.dto.request.FeedListRequest;
+import com.team.buddyya.feed.dto.response.FeedListResponse;
+import com.team.buddyya.feed.dto.response.FeedResponse;
+import com.team.buddyya.feed.service.FeedService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/feeds")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedService feedService;
+
+    @GetMapping
+    public ResponseEntity<FeedListResponse> getFeeds(@ModelAttribute FeedListRequest request) {
+        return ResponseEntity.ok(feedService.getFeeds(request));
+    }
+
+    @GetMapping("/{feedId}")
+    public ResponseEntity<FeedResponse> getFeed(@PathVariable Long feedId) {
+        return ResponseEntity.ok(feedService.getFeed(feedId))
+    }
+
+}

--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -1,11 +1,13 @@
 package com.team.buddyya.feed.controller;
 
+import com.team.buddyya.auth.domain.CustomUserDetails;
 import com.team.buddyya.feed.dto.request.FeedListRequest;
 import com.team.buddyya.feed.dto.response.FeedListResponse;
 import com.team.buddyya.feed.dto.response.FeedResponse;
 import com.team.buddyya.feed.service.FeedService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,13 +22,16 @@ public class FeedController {
     private final FeedService feedService;
 
     @GetMapping
-    public ResponseEntity<FeedListResponse> getFeeds(@ModelAttribute FeedListRequest request) {
-        return ResponseEntity.ok(feedService.getFeeds(request));
+    public ResponseEntity<FeedListResponse> getFeeds(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                     @ModelAttribute FeedListRequest request) {
+        FeedListResponse response = feedService.getFeeds(userDetails.getStudentInfo(), request);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{feedId}")
-    public ResponseEntity<FeedResponse> getFeed(@PathVariable Long feedId) {
-        return ResponseEntity.ok(feedService.getFeed(feedId))
+    public ResponseEntity<FeedResponse> getFeed(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                @PathVariable Long feedId) {
+        FeedResponse response = feedService.getFeed(userDetails.getStudentInfo(), feedId);
+        return ResponseEntity.ok(response);
     }
-
 }

--- a/src/main/java/com/team/buddyya/feed/domain/BookMark.java
+++ b/src/main/java/com/team/buddyya/feed/domain/BookMark.java
@@ -1,0 +1,42 @@
+package com.team.buddyya.feed.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.team.buddyya.common.domain.CreatedTime;
+import com.team.buddyya.student.domain.Student;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "bookmark")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class BookMark extends CreatedTime {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @Builder
+    public BookMark(Feed feed, Student student) {
+        this.feed = feed;
+        this.student = student;
+    }
+}

--- a/src/main/java/com/team/buddyya/feed/domain/Category.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Category.java
@@ -1,4 +1,32 @@
 package com.team.buddyya.feed.domain;
 
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "category")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Category {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(length = 15, nullable = false)
+    private String name;
+
+    @Builder
+    public Category(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/Comment.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Comment.java
@@ -1,4 +1,46 @@
 package com.team.buddyya.feed.domain;
 
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.team.buddyya.student.domain.Student;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Builder
+    public Comment(Student student, Feed feed, String content) {
+        this.student = student;
+        this.feed = feed;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -64,6 +64,9 @@ public class Feed extends BaseTime {
     @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Like> likes;
 
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<BookMark> bookmarks;
+
     @Builder
     public Feed(String title, String content, Student student, Category category, University university) {
         this.title = title;

--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -78,6 +78,12 @@ public class Feed extends BaseTime {
         this.commentCount = 0;
     }
 
+    public void updateFeed(String title, String content, Category category) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+    }
+
     public void increaseLikeCount() {
         this.likeCount++;
     }

--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -1,4 +1,93 @@
 package com.team.buddyya.feed.domain;
 
-public class Feed {
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.team.buddyya.common.domain.BaseTime;
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.domain.University;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "feed")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Feed extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(length = 255, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "like_count", nullable = false)
+    private int likeCount;
+
+    @Column(name = "comment_count", nullable = false)
+    private int commentCount;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "university_id", nullable = false)
+    private University university;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<FeedImage> images;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Like> likes;
+
+    @Builder
+    public Feed(String title, String content, Student student, Category category, University university) {
+        this.title = title;
+        this.content = content;
+        this.student = student;
+        this.category = category;
+        this.university = university;
+        this.likeCount = 0;
+        this.commentCount = 0;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount--;
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        this.commentCount--;
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/FeedImage.java
+++ b/src/main/java/com/team/buddyya/feed/domain/FeedImage.java
@@ -4,7 +4,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-import com.team.buddyya.common.domain.BaseTime;
+import com.team.buddyya.common.domain.CreatedTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "feed_image")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class FeedImage extends BaseTime {
+public class FeedImage extends CreatedTime {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/com/team/buddyya/feed/domain/FeedImage.java
+++ b/src/main/java/com/team/buddyya/feed/domain/FeedImage.java
@@ -1,4 +1,41 @@
 package com.team.buddyya.feed.domain;
 
-public class FeedImage {
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.team.buddyya.common.domain.BaseTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "feed_image")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FeedImage extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    @Column(length = 255, nullable = false)
+    private String url;
+
+    @Builder
+    public FeedImage(Feed feed, String url) {
+        this.feed = feed;
+        this.url = url;
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/FeedUserAction.java
+++ b/src/main/java/com/team/buddyya/feed/domain/FeedUserAction.java
@@ -1,0 +1,11 @@
+package com.team.buddyya.feed.domain;
+
+public record FeedUserAction(
+        boolean isLiked,
+        boolean isBookmarked
+) {
+
+    public static FeedUserAction from(boolean isLiked, boolean isBookmarked) {
+        return new FeedUserAction(isLiked, isBookmarked);
+    }
+}

--- a/src/main/java/com/team/buddyya/feed/domain/Like.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Like.java
@@ -1,4 +1,43 @@
 package com.team.buddyya.feed.domain;
 
-public class Like {
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.team.buddyya.common.domain.CreatedTime;
+import com.team.buddyya.student.domain.Student;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "like")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Like extends CreatedTime {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @Builder
+    public Like(Feed feed, Student student) {
+        this.feed = feed;
+        this.student = student;
+    }
+
 }

--- a/src/main/java/com/team/buddyya/feed/domain/Like.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Like.java
@@ -39,5 +39,4 @@ public class Like extends CreatedTime {
         this.feed = feed;
         this.student = student;
     }
-
 }

--- a/src/main/java/com/team/buddyya/feed/dto/request/FeedCreateRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/FeedCreateRequest.java
@@ -1,0 +1,8 @@
+package com.team.buddyya.feed.dto.request;
+
+public record FeedCreateRequest(
+        String title,
+        String content,
+        String category
+) {
+}

--- a/src/main/java/com/team/buddyya/feed/dto/request/FeedListRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/FeedListRequest.java
@@ -1,0 +1,9 @@
+package com.team.buddyya.feed.dto.request;
+
+public record FeedListRequest(
+        int page,
+        int size,
+        String category,
+        String keyword
+) {
+}

--- a/src/main/java/com/team/buddyya/feed/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/FeedUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.team.buddyya.feed.dto.request;
+
+public record FeedUpdateRequest(
+        String title,
+        String content,
+        String category
+) {
+}

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedCreateResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedCreateResponse.java
@@ -1,8 +1,6 @@
 package com.team.buddyya.feed.dto.response;
 
-public record FeedCreateResponse(
-        Long id
-) {
+public record FeedCreateResponse(Long id) {
 
     public static FeedCreateResponse from(Long id) {
         return new FeedCreateResponse(id);

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedCreateResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedCreateResponse.java
@@ -1,0 +1,10 @@
+package com.team.buddyya.feed.dto.response;
+
+public record FeedCreateResponse(
+        Long id
+) {
+
+    public static FeedCreateResponse from(Long id) {
+        return new FeedCreateResponse(id);
+    }
+}

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedListItemResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedListItemResponse.java
@@ -1,0 +1,17 @@
+package com.team.buddyya.feed.dto.response;
+
+import java.time.LocalDateTime;
+
+public record FeedListItemResponse(
+        Long id,
+        String studentName,
+        String country,
+        String title,
+        String content,
+        int likeCount,
+        int commentCount,
+        boolean isLiked,
+        boolean isBookmarked,
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedListItemResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedListItemResponse.java
@@ -1,10 +1,11 @@
 package com.team.buddyya.feed.dto.response;
 
+import com.team.buddyya.feed.domain.Feed;
 import java.time.LocalDateTime;
 
 public record FeedListItemResponse(
         Long id,
-        String studentName,
+        String name,
         String country,
         String title,
         String content,
@@ -14,4 +15,19 @@ public record FeedListItemResponse(
         boolean isBookmarked,
         LocalDateTime createdDate
 ) {
+
+    public static FeedListItemResponse from(Feed feed, boolean isLiked, boolean isBookmarked) {
+        return new FeedListItemResponse(
+                feed.getId(),
+                feed.getStudent().getName(),
+                feed.getStudent().getCountry(),
+                feed.getTitle(),
+                feed.getContent(),
+                feed.getLikeCount(),
+                feed.getCommentCount(),
+                isLiked,
+                isBookmarked,
+                feed.getCreatedDate()
+        );
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedListResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedListResponse.java
@@ -1,6 +1,8 @@
 package com.team.buddyya.feed.dto.response;
 
+import com.team.buddyya.feed.domain.Feed;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public record FeedListResponse(
         List<FeedListItemResponse> feeds,
@@ -8,4 +10,13 @@ public record FeedListResponse(
         int totalPages,
         boolean hasNext
 ) {
+
+    public static FeedListResponse from(Page<Feed> feeds, List<FeedListItemResponse> feedResponses) {
+        return new FeedListResponse(
+                feedResponses,
+                feeds.getNumber(),
+                feeds.getTotalPages(),
+                feeds.hasNext()
+        );
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedListResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedListResponse.java
@@ -1,0 +1,11 @@
+package com.team.buddyya.feed.dto.response;
+
+import java.util.List;
+
+public record FeedListResponse(
+        List<FeedListItemResponse> feeds,
+        int currentPage,
+        int totalPages,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedListResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedListResponse.java
@@ -11,12 +11,12 @@ public record FeedListResponse(
         boolean hasNext
 ) {
 
-    public static FeedListResponse from(Page<Feed> feeds, List<FeedListItemResponse> feedResponses) {
+    public static FeedListResponse from(Page<Feed> feedInfo, List<FeedListItemResponse> feeds) {
         return new FeedListResponse(
-                feedResponses,
-                feeds.getNumber(),
-                feeds.getTotalPages(),
-                feeds.hasNext()
+                feeds,
+                feedInfo.getNumber(),
+                feedInfo.getTotalPages(),
+                feedInfo.hasNext()
         );
     }
 }

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedResponse.java
@@ -1,5 +1,6 @@
 package com.team.buddyya.feed.dto.response;
 
+import com.team.buddyya.feed.domain.Feed;
 import java.time.LocalDateTime;
 
 public record FeedResponse(
@@ -14,4 +15,19 @@ public record FeedResponse(
         boolean isBookmarked,
         LocalDateTime createdDate
 ) {
+
+    public static FeedResponse from(Feed feed, boolean isLiked, boolean isBookmarked) {
+        return new FeedResponse(
+                feed.getId(),
+                feed.getStudent().getName(),
+                feed.getStudent().getCountry(),
+                feed.getTitle(),
+                feed.getContent(),
+                feed.getLikeCount(),
+                feed.getCommentCount(),
+                isLiked,
+                isBookmarked,
+                feed.getCreatedDate()
+        );
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/dto/response/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/FeedResponse.java
@@ -1,0 +1,17 @@
+package com.team.buddyya.feed.dto.response;
+
+import java.time.LocalDateTime;
+
+public record FeedResponse(
+        Long id,
+        String name,
+        String country,
+        String title,
+        String content,
+        int likeCount,
+        int commentCount,
+        boolean isLiked,
+        boolean isBookmarked,
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/com/team/buddyya/feed/exception/FeedException.java
+++ b/src/main/java/com/team/buddyya/feed/exception/FeedException.java
@@ -1,0 +1,18 @@
+package com.team.buddyya.feed.exception;
+
+import com.team.buddyya.common.exception.BaseException;
+import com.team.buddyya.common.exception.BaseExceptionType;
+
+public class FeedException extends BaseException {
+
+    private final FeedExceptionType exceptionType;
+
+    public FeedException(FeedExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
+++ b/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
@@ -1,0 +1,34 @@
+package com.team.buddyya.feed.exception;
+
+import com.team.buddyya.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum FeedExceptionType implements BaseExceptionType {
+
+    CATEGORY_NOT_FOUND(200, HttpStatus.NOT_FOUND, "해당 카테고리를 찾지 못했습니다.");
+
+    private final int errorCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    FeedExceptionType(int errorCode, HttpStatus httpStatus, String errorMessage) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public int errorCode() {
+        return errorCode();
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus();
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage();
+    }
+}

--- a/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
+++ b/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum FeedExceptionType implements BaseExceptionType {
 
     FEED_NOT_FOUND(400, HttpStatus.NOT_FOUND, "해당 피드를 찾지 못했습니다."),
-    CATEGORY_NOT_FOUND(400, HttpStatus.NOT_FOUND, "해당 카테고리를 찾지 못했습니다.");
+    CATEGORY_NOT_FOUND(400, HttpStatus.NOT_FOUND, "해당 카테고리를 찾지 못했습니다."),
+    NOT_FEED_OWNER(403, HttpStatus.FORBIDDEN, "해당 피드의 글쓴이기 아닙니다.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
+++ b/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum FeedExceptionType implements BaseExceptionType {
 
-    CATEGORY_NOT_FOUND(200, HttpStatus.NOT_FOUND, "해당 카테고리를 찾지 못했습니다.");
+    FEED_NOT_FOUND(400, HttpStatus.NOT_FOUND, "해당 피드를 찾지 못했습니다."),
+    CATEGORY_NOT_FOUND(400, HttpStatus.NOT_FOUND, "해당 카테고리를 찾지 못했습니다.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/feed/respository/BookmarkRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/BookmarkRepository.java
@@ -4,4 +4,6 @@ import com.team.buddyya.feed.domain.BookMark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<BookMark, Long> {
+
+    boolean existsByStudentIdAndFeedId(Long studentId, Long feedId);
 }

--- a/src/main/java/com/team/buddyya/feed/respository/BookmarkRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package com.team.buddyya.feed.respository;
+
+import com.team.buddyya.feed.domain.BookMark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<BookMark, Long> {
+}

--- a/src/main/java/com/team/buddyya/feed/respository/CategoryRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.team.buddyya.feed.respository;
+
+import com.team.buddyya.feed.domain.Category;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    
+    Optional<Category> findByName(String category);
+}

--- a/src/main/java/com/team/buddyya/feed/respository/CommentRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.team.buddyya.feed.respository;
+
+import com.team.buddyya.feed.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
@@ -1,7 +1,12 @@
 package com.team.buddyya.feed.respository;
 
+import com.team.buddyya.feed.domain.Category;
 import com.team.buddyya.feed.domain.Feed;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+    Page<Feed> findAllByCategory(Category category, Pageable pageable);
 }

--- a/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
@@ -1,0 +1,7 @@
+package com.team.buddyya.feed.respository;
+
+import com.team.buddyya.feed.domain.Feed;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+}

--- a/src/main/java/com/team/buddyya/feed/respository/LikeRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/LikeRepository.java
@@ -4,4 +4,6 @@ import com.team.buddyya.feed.domain.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    boolean existsByStudentIdAndFeedId(Long studentId, Long feedId);
 }

--- a/src/main/java/com/team/buddyya/feed/respository/LikeRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/LikeRepository.java
@@ -1,0 +1,7 @@
+package com.team.buddyya.feed.respository;
+
+import com.team.buddyya.feed.domain.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+}

--- a/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
+++ b/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
@@ -1,0 +1,18 @@
+package com.team.buddyya.feed.service;
+
+import com.team.buddyya.feed.respository.BookmarkRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+
+    public boolean isBookmarkedByStudent(Long studentId, Long feedId) {
+        return bookmarkRepository.existsByStudentIdAndFeedId(studentId, feedId);
+    }
+}

--- a/src/main/java/com/team/buddyya/feed/service/CategoryService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CategoryService.java
@@ -1,0 +1,22 @@
+package com.team.buddyya.feed.service;
+
+import com.team.buddyya.feed.domain.Category;
+import com.team.buddyya.feed.exception.FeedException;
+import com.team.buddyya.feed.exception.FeedExceptionType;
+import com.team.buddyya.feed.respository.CategoryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CategoryService {
+    
+    private final CategoryRepository categoryRepository;
+
+    public Category getCategory(String categoryName) {
+        return categoryRepository.findByName(categoryName)
+                .orElseThrow(() -> new FeedException(FeedExceptionType.CATEGORY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -7,7 +7,6 @@ import com.team.buddyya.feed.domain.FeedUserAction;
 import com.team.buddyya.feed.dto.request.FeedCreateRequest;
 import com.team.buddyya.feed.dto.request.FeedListRequest;
 import com.team.buddyya.feed.dto.request.FeedUpdateRequest;
-import com.team.buddyya.feed.dto.response.FeedCreateResponse;
 import com.team.buddyya.feed.dto.response.FeedListItemResponse;
 import com.team.buddyya.feed.dto.response.FeedListResponse;
 import com.team.buddyya.feed.dto.response.FeedResponse;
@@ -37,6 +36,10 @@ public class FeedService {
     private final FeedRepository feedRepository;
     private final StudentRepository studentRepository;
 
+    public Feed findFeedById(Long feedId) {
+        return feedRepository.findById(feedId).orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
+    }
+
     public FeedListResponse getFeeds(StudentInfo studentInfo, FeedListRequest request) {
         Category category = categoryService.getCategory(request.category());
         PageRequest pageRequest = PageRequest.of(request.page(), request.size(),
@@ -54,7 +57,7 @@ public class FeedService {
         return FeedResponse.from(feed, userAction.isLiked(), userAction.isBookmarked());
     }
 
-    public FeedCreateResponse createFeed(StudentInfo studentInfo, FeedCreateRequest request) {
+    public void createFeed(StudentInfo studentInfo, FeedCreateRequest request) {
         Category category = categoryService.getCategory(request.category());
         Student student = studentRepository.findById(studentInfo.id())
                 .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
@@ -65,7 +68,7 @@ public class FeedService {
                 .category(category)
                 .university(student.getUniversity())
                 .build();
-        return FeedCreateResponse.from(feedRepository.save(feed).getId());
+        feedRepository.save(feed);
     }
 
     public void updateFeed(StudentInfo studentInfo, Long feedId, FeedUpdateRequest request) {
@@ -79,10 +82,6 @@ public class FeedService {
         Feed feed = findFeedById(feedId);
         validateFeedOwner(studentInfo.id(), feed);
         feedRepository.delete(feed);
-    }
-
-    public Feed findFeedById(Long feedId) {
-        return feedRepository.findById(feedId).orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }
 
     private void validateFeedOwner(Long studentId, Feed feed) {

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -37,7 +37,8 @@ public class FeedService {
     private final StudentRepository studentRepository;
 
     public Feed findFeedById(Long feedId) {
-        return feedRepository.findById(feedId).orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
+        return feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }
 
     public FeedListResponse getFeeds(StudentInfo studentInfo, FeedListRequest request) {

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -1,7 +1,46 @@
 package com.team.buddyya.feed.service;
 
+import com.team.buddyya.auth.domain.StudentInfo;
+import com.team.buddyya.feed.domain.Category;
+import com.team.buddyya.feed.domain.Feed;
+import com.team.buddyya.feed.dto.request.FeedListRequest;
+import com.team.buddyya.feed.dto.response.FeedListItemResponse;
+import com.team.buddyya.feed.dto.response.FeedListResponse;
+import com.team.buddyya.feed.respository.FeedRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class FeedService {
+
+    private final FeedRepository feedRepository;
+    private final LikeSevice likeSevice;
+    private final BookmarkService bookmarkService;
+    private final CategoryService categoryService;
+
+    public FeedListResponse getFeeds(StudentInfo studentInfo, FeedListRequest request) {
+        Category category = categoryService.getCategory(request.category());
+        PageRequest pageRequest = PageRequest.of(request.page(), request.size(),
+                Sort.by(Sort.Direction.DESC, "createdDate"));
+        Page<Feed> feeds = feedRepository.findAllByCategory(category, pageRequest);
+        List<FeedListItemResponse> feedResponses = feeds.getContent().stream()
+                .map(feed -> createFeedListItemResponse(feed, studentInfo))
+                .toList();
+        return FeedListResponse.from(feeds, feedResponses);
+    }
+
+    private FeedListItemResponse createFeedListItemResponse(Feed feed, StudentInfo studentInfo) {
+        Long feedId = feed.getId();
+        Long studentId = studentInfo.id();
+        boolean isLiked = likeSevice.isLikedByStudent(studentId, feedId);
+        boolean isBookmarked = bookmarkService.isBookmarkedByStudent(studentId, feedId);
+        return FeedListItemResponse.from(feed, isLiked, isBookmarked);
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -1,0 +1,7 @@
+package com.team.buddyya.feed.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class FeedService {
+}

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -67,6 +67,13 @@ public class FeedService {
         return FeedCreateResponse.from(feedRepository.save(feed).getId());
     }
 
+    public void deleteFeed(StudentInfo studentInfo, Long feedId) {
+        Feed feed = findFeedById(feedId);
+        if (!studentInfo.id().equals(feed.getStudent().getId())) {
+            throw new FeedException(FeedExceptionType.NOT_FEED_OWNER);
+        }
+    }
+
     public Feed findFeedById(Long feedId) {
         return feedRepository.findById(feedId).orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }

--- a/src/main/java/com/team/buddyya/feed/service/LikeSevice.java
+++ b/src/main/java/com/team/buddyya/feed/service/LikeSevice.java
@@ -1,0 +1,18 @@
+package com.team.buddyya.feed.service;
+
+import com.team.buddyya.feed.respository.LikeRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LikeSevice {
+
+    private final LikeRepository likeRepository;
+
+    public boolean isLikedByStudent(Long studentId, Long feedId) {
+        return likeRepository.existsByStudentIdAndFeedId(studentId, feedId);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
[피드 기능 개발 #22](https://github.com/buddy-ya/be/issues/22)
<br><br>

## 🛠️ 작업 내용
- Feed 및 관련 Entity 구현 (Feed, Category, Like, Bookmark)
- 피드 목록 조회/상세 조회/생성/수정/삭제 API 구현
- 피드 조회시 Page 처리를 통한 피드 목록 페이지네이션 구현 

피드에 `댓글`, `좋아요 및 북마크`, `사진 파일`에 대한 부분은 다음 PR에 구현하겠습니다.
<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가?
- 예외처리가 빠진 부분은 없는가?
- 조회의 경우 조회를 한 곳에서 `Optional` 예외처리를 하지않고 
해당 도메인의 서비스 계층에서 `findBy-` 메서드를 제공하여 예외처리 코드의 중복 방지.
- 메서드안에서 개행을 하지못하므로 메서드가 길어졌을 때 분리하여 가독성을 높임. 
<br><br>
## 🤔 고민한 점
### 페이지네이션 구현 배경
- 게시글이 50개만 넘어가도 프론트엔드 렌더링 성능에 영향이 있을 것으로 판단
- Spring Data JPA의 페이징 기능을 활용하여 10개씩 피드 목록 반환하도록 구현
- 저희 게시글은 조회 기준에 카테고리가 있기 때문에, `Pageable` 로 요청을 받기에는 제한이 있었습니다.
따라서 카테고리 필드가 담긴 `RequestDTO`를 만들어 요청을 처리했습니다.

### 논의하고 싶은 점
- `Repositroy`에서 조회 기능을 수행하면 `Optional`객체가 반환되기 때문에, 요청한 쪽에서 반드시 예외처리를 해야합니다.
-  조회의 경우 해당 서비스 계층에서 예외처리까지 진행하고 조회된 객체를 반환하는 메서드를 제공하는건 어떨까요?
<br><br>

## 📎 커밋 범위 링크

<br><br>
