### PR TITLE
feat: 관리자의 학생증 인증 승인, 반려하는 기능

### DIFF
--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -2,14 +2,11 @@ package com.team.buddyya.admin.controller;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
-import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,8 +17,7 @@ public class AdminController {
 
     @GetMapping("/student-id-cards")
     public ResponseEntity<StudentIdCardListResponse> getStudentIdCards() {
-        List<StudentIdCardResponse> studentIdCards = adminService.getStudentIdCards();
-        return ResponseEntity.ok(new StudentIdCardListResponse(studentIdCards));
+        return ResponseEntity.ok(adminService.getStudentIdCards());
     }
 
     @PostMapping("/student-id-cards/verify")

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -21,7 +21,7 @@ public class AdminController {
     @GetMapping("/student-id-cards")
     public ResponseEntity<StudentIdCardListResponse> getStudentIdCards() {
         List<StudentIdCardResponse> studentIdCards = adminService.getStudentIdCards();
-        return ResponseEntity.ok(new StudentIdCardListResponse(adminService.getStudentIdCards()));
+        return ResponseEntity.ok(new StudentIdCardListResponse(studentIdCards));
     }
 
     @PostMapping("/student-id-cards/verify")

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.team.buddyya.admin.controller;
+
+import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
+import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
+import com.team.buddyya.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("/student-id-cards")
+    public ResponseEntity<StudentIdCardListResponse> getStudentIdCards() {
+        List<StudentIdCardResponse> studentIdCards = adminService.getStudentIdCards();
+        return ResponseEntity.ok(new StudentIdCardListResponse(adminService.getStudentIdCards()));
+    }
+}

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -1,13 +1,13 @@
 package com.team.buddyya.admin.controller;
 
+import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
+import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,5 +22,10 @@ public class AdminController {
     public ResponseEntity<StudentIdCardListResponse> getStudentIdCards() {
         List<StudentIdCardResponse> studentIdCards = adminService.getStudentIdCards();
         return ResponseEntity.ok(new StudentIdCardListResponse(adminService.getStudentIdCards()));
+    }
+
+    @PostMapping("/student-id-cards/verify")
+    public ResponseEntity<StudentVerificationResponse> verifyStudentIdCard(@RequestBody StudentVerificationRequest request) {
+        return ResponseEntity.ok(adminService.verifyStudentIdCard(request));
     }
 }

--- a/src/main/java/com/team/buddyya/admin/dto/request/StudentVerificationRequest.java
+++ b/src/main/java/com/team/buddyya/admin/dto/request/StudentVerificationRequest.java
@@ -1,0 +1,8 @@
+package com.team.buddyya.admin.dto.request;
+
+public record StudentVerificationRequest(
+        Long studentId,
+        String imageUrl,
+        Integer studentNumber
+) {
+}

--- a/src/main/java/com/team/buddyya/admin/dto/request/StudentVerificationRequest.java
+++ b/src/main/java/com/team/buddyya/admin/dto/request/StudentVerificationRequest.java
@@ -3,6 +3,6 @@ package com.team.buddyya.admin.dto.request;
 public record StudentVerificationRequest(
         Long studentId,
         String imageUrl,
-        Integer studentNumber
+        String studentNumber
 ) {
 }

--- a/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardListResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardListResponse.java
@@ -1,0 +1,6 @@
+package com.team.buddyya.admin.dto.response;
+
+import java.util.List;
+
+public record StudentIdCardListResponse(List<StudentIdCardResponse> studentIdCards) {
+}

--- a/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardListResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardListResponse.java
@@ -3,4 +3,8 @@ package com.team.buddyya.admin.dto.response;
 import java.util.List;
 
 public record StudentIdCardListResponse(List<StudentIdCardResponse> studentIdCards) {
+
+    public static StudentIdCardListResponse from(List<StudentIdCardResponse> studentIdCards) {
+        return new StudentIdCardListResponse(studentIdCards);
+    }
 }

--- a/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardResponse.java
@@ -1,0 +1,19 @@
+package com.team.buddyya.admin.dto.response;
+
+import com.team.buddyya.certification.domain.StudentIdCard;
+
+public record StudentIdCardResponse(
+
+        Long id,
+        Long studentId,
+        String imageUrl
+) {
+
+    public static StudentIdCardResponse from(StudentIdCard studentIdCard) {
+        return new StudentIdCardResponse(
+                studentIdCard.getId(),
+                studentIdCard.getStudent().getId(),
+                studentIdCard.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardResponse.java
@@ -3,7 +3,6 @@ package com.team.buddyya.admin.dto.response;
 import com.team.buddyya.certification.domain.StudentIdCard;
 
 public record StudentIdCardResponse(
-
         Long id,
         Long studentId,
         String imageUrl

--- a/src/main/java/com/team/buddyya/admin/dto/response/StudentVerificationResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/StudentVerificationResponse.java
@@ -1,0 +1,4 @@
+package com.team.buddyya.admin.dto.response;
+
+public record StudentVerificationResponse(boolean success) {
+}

--- a/src/main/java/com/team/buddyya/admin/dto/response/StudentVerificationResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/StudentVerificationResponse.java
@@ -1,4 +1,4 @@
 package com.team.buddyya.admin.dto.response;
 
-public record StudentVerificationResponse(boolean success) {
+public record StudentVerificationResponse(String message) {
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -1,0 +1,28 @@
+package com.team.buddyya.admin.service;
+
+import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
+import com.team.buddyya.certification.domain.StudentIdCard;
+import com.team.buddyya.certification.repository.StudentIdCardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminService {
+
+    private final StudentIdCardRepository studentIdCardRepository;
+
+    public List<StudentIdCardResponse> getStudentIdCards() {
+        List<StudentIdCard> studentIdCards = studentIdCardRepository.findAllByOrderByCreatedDateAsc();
+        List<StudentIdCardResponse> studentIdCardResponses = new ArrayList<>();
+        for(StudentIdCard studentIdCard : studentIdCards) {
+            studentIdCardResponses.add(StudentIdCardResponse.from(studentIdCard));
+        }
+        return studentIdCardResponses;
+    }
+}

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -42,10 +42,10 @@ public class AdminService {
     }
 
     public StudentVerificationResponse verifyStudentIdCard(StudentVerificationRequest request) {
-        s3UploadService.deleteFile(STUDENT_ID_CARD.getDirectoryName(), request.imageUrl());
         Student student = studentRepository.findById(request.studentId())
                 .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
         studentIdCardRepository.deleteByStudent(student);
+        s3UploadService.deleteFile(STUDENT_ID_CARD.getDirectoryName(), request.imageUrl());
         if (request.studentNumber() == null) {
             return new StudentVerificationResponse(REQUEST_REJECTED_MESSAGE);
         }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -1,12 +1,12 @@
 package com.team.buddyya.admin.service;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
+import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.student.domain.Student;
-import com.team.buddyya.student.domain.University;
 import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.StudentRepository;
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.team.buddyya.common.domain.S3DirectoryName.STUDENT_ID_CARD;
@@ -35,10 +34,11 @@ public class AdminService {
     private final StudentIdCardRepository studentIdCardRepository;
     private final S3UploadService s3UploadService;
 
-    public List<StudentIdCardResponse> getStudentIdCards() {
-        return studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
+    public StudentIdCardListResponse getStudentIdCards() {
+        List<StudentIdCardResponse> studentIdCards = studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
                 .map(StudentIdCardResponse::from)
                 .collect(Collectors.toList());
+        return new StudentIdCardListResponse(studentIdCards);
     }
 
     public StudentVerificationResponse verifyStudentIdCard(StudentVerificationRequest request) {

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -38,7 +38,7 @@ public class AdminService {
         List<StudentIdCardResponse> studentIdCards = studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
                 .map(StudentIdCardResponse::from)
                 .collect(Collectors.toList());
-        return new StudentIdCardListResponse(studentIdCards);
+        return StudentIdCardListResponse.from(studentIdCards);
     }
 
     public StudentVerificationResponse verifyStudentIdCard(StudentVerificationRequest request) {

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -1,26 +1,52 @@
 package com.team.buddyya.admin.service;
 
+import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
 import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
-import com.team.buddyya.certification.domain.StudentIdCard;
+import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
+import com.team.buddyya.common.service.S3UploadService;
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.exception.StudentException;
+import com.team.buddyya.student.exception.StudentExceptionType;
+import com.team.buddyya.student.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.team.buddyya.common.domain.S3DirectoryName.STUDENT_ID_CARD;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class AdminService {
 
+    private final StudentRepository studentRepository;
     private final StudentIdCardRepository studentIdCardRepository;
+    private final S3UploadService s3UploadService;
 
     public List<StudentIdCardResponse> getStudentIdCards() {
         return studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
                 .map(StudentIdCardResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    public StudentVerificationResponse verifyStudentIdCard(StudentVerificationRequest request) {
+        s3UploadService.deleteFile(STUDENT_ID_CARD.getDirectoryName(), request.imageUrl());
+        Student student = studentRepository.findById(request.studentId())
+                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+        studentIdCardRepository.deleteByStudent(student);
+        if(request.studentNumber() == null){
+            return new StudentVerificationResponse(true);
+        }
+        Optional<Student> existingStudent = studentRepository.findByStudentNumberAndUniversity(request.studentNumber(), student.getUniversity());
+        if (existingStudent.isPresent()) {
+            return new StudentVerificationResponse(false);
+        }
+        student.updateIsCertificated(true);
+        student.updateStudentNumber(request.studentNumber());
+        return new StudentVerificationResponse(true);
     }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,11 +19,8 @@ public class AdminService {
     private final StudentIdCardRepository studentIdCardRepository;
 
     public List<StudentIdCardResponse> getStudentIdCards() {
-        List<StudentIdCard> studentIdCards = studentIdCardRepository.findAllByOrderByCreatedDateAsc();
-        List<StudentIdCardResponse> studentIdCardResponses = new ArrayList<>();
-        for(StudentIdCard studentIdCard : studentIdCards) {
-            studentIdCardResponses.add(StudentIdCardResponse.from(studentIdCard));
-        }
-        return studentIdCardResponses;
+        return studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
+                .map(StudentIdCardResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -26,6 +26,10 @@ import static com.team.buddyya.common.domain.S3DirectoryName.STUDENT_ID_CARD;
 @Transactional
 public class AdminService {
 
+    private static final String REQUEST_REJECTED_MESSAGE = "인증 요청이 거절되었습니다";
+    private static final String ALREADY_REGISTERED_MESSAGE = "이미 등록된 학번입니다";
+    private static final String VERIFICATION_COMPLETED_MESSAGE = "학생 인증이 완료되었습니다";
+
     private final StudentService studentService;
     private final StudentRepository studentRepository;
     private final StudentIdCardRepository studentIdCardRepository;
@@ -43,12 +47,12 @@ public class AdminService {
                 .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
         studentIdCardRepository.deleteByStudent(student);
         if (request.studentNumber() == null) {
-            return new StudentVerificationResponse(true);
+            return new StudentVerificationResponse(REQUEST_REJECTED_MESSAGE);
         }
         if (studentService.isDuplicateStudentNumber(request.studentNumber(), student.getUniversity())) {
-            return new StudentVerificationResponse(false);
+            return new StudentVerificationResponse(ALREADY_REGISTERED_MESSAGE);
         }
         studentService.updateStudentCertification(student, request.studentNumber());
-        return new StudentVerificationResponse(true);
+        return new StudentVerificationResponse(VERIFICATION_COMPLETED_MESSAGE);
     }
 }

--- a/src/main/java/com/team/buddyya/certification/domain/StudentIdCard.java
+++ b/src/main/java/com/team/buddyya/certification/domain/StudentIdCard.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import static jakarta.persistence.FetchType.LAZY;
+
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -23,7 +23,7 @@ public class StudentIdCard extends CreatedTime {
     @Column(nullable = false)
     private String imageUrl;
 
-    @ManyToOne(fetch = LAZY)
+    @OneToOne
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
 
@@ -31,5 +31,9 @@ public class StudentIdCard extends CreatedTime {
     public StudentIdCard(String imageUrl, Student student) {
         this.imageUrl = imageUrl;
         this.student = student;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/team/buddyya/certification/repository/StudentIdCardRepository.java
+++ b/src/main/java/com/team/buddyya/certification/repository/StudentIdCardRepository.java
@@ -12,4 +12,6 @@ public interface StudentIdCardRepository extends JpaRepository<StudentIdCard, Lo
     Optional<StudentIdCard> findByStudent(Student student);
 
     List<StudentIdCard> findAllByOrderByCreatedDateAsc();
+
+    void deleteByStudent(Student student);
 }

--- a/src/main/java/com/team/buddyya/certification/repository/StudentIdCardRepository.java
+++ b/src/main/java/com/team/buddyya/certification/repository/StudentIdCardRepository.java
@@ -3,10 +3,13 @@ package com.team.buddyya.certification.repository;
 import com.team.buddyya.certification.domain.StudentIdCard;
 import com.team.buddyya.student.domain.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 import java.util.Optional;
+
 
 public interface StudentIdCardRepository extends JpaRepository<StudentIdCard, Long> {
 
     Optional<StudentIdCard> findByStudent(Student student);
+
+    List<StudentIdCard> findAllByOrderByCreatedDateAsc();
 }

--- a/src/main/java/com/team/buddyya/certification/repository/StudentIdCardRepository.java
+++ b/src/main/java/com/team/buddyya/certification/repository/StudentIdCardRepository.java
@@ -1,7 +1,12 @@
 package com.team.buddyya.certification.repository;
 
 import com.team.buddyya.certification.domain.StudentIdCard;
+import com.team.buddyya.student.domain.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface StudentIdCardRepository extends JpaRepository<StudentIdCard, Long> {
+
+    Optional<StudentIdCard> findByStudent(Student student);
 }

--- a/src/main/java/com/team/buddyya/certification/service/CertificationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/CertificationService.java
@@ -19,8 +19,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.team.buddyya.common.domain.S3DirectoryName.STUDENT_ID_CARD;
 
@@ -75,6 +77,12 @@ public class CertificationService {
             throw new CertificateException(CertificateExceptionType.ALREADY_CERTIFICATED);
         }
         String imageUrl = s3UploadService.uploadFile(STUDENT_ID_CARD.getDirectoryName(), file);
+        Optional<StudentIdCard> existStudentIdCard = studentIdCardRepository.findByStudent(student);
+        if (existStudentIdCard.isPresent()) {
+            s3UploadService.deleteFile(STUDENT_ID_CARD.getDirectoryName(), existStudentIdCard.get().getImageUrl());
+            existStudentIdCard.get().updateImageUrl(imageUrl);
+            return new CertificationResponse(true);
+        }
         StudentIdCard studentIdCard = StudentIdCard.builder()
                 .imageUrl(imageUrl)
                 .student(student)

--- a/src/main/java/com/team/buddyya/certification/service/CertificationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/CertificationService.java
@@ -79,15 +79,19 @@ public class CertificationService {
         String imageUrl = s3UploadService.uploadFile(STUDENT_ID_CARD.getDirectoryName(), file);
         Optional<StudentIdCard> existStudentIdCard = studentIdCardRepository.findByStudent(student);
         if (existStudentIdCard.isPresent()) {
-            s3UploadService.deleteFile(STUDENT_ID_CARD.getDirectoryName(), existStudentIdCard.get().getImageUrl());
-            existStudentIdCard.get().updateImageUrl(imageUrl);
-            return new CertificationResponse(true);
+            return updateExistingStudentIdCard(imageUrl, existStudentIdCard.get());
         }
         StudentIdCard studentIdCard = StudentIdCard.builder()
                 .imageUrl(imageUrl)
                 .student(student)
                 .build();
         studentIdCardRepository.save(studentIdCard);
+        return new CertificationResponse(true);
+    }
+
+    private CertificationResponse updateExistingStudentIdCard(String imageUrl, StudentIdCard existStudentIdCard) {
+        s3UploadService.deleteFile(STUDENT_ID_CARD.getDirectoryName(), existStudentIdCard.getImageUrl());
+        existStudentIdCard.updateImageUrl(imageUrl);
         return new CertificationResponse(true);
     }
 

--- a/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
+++ b/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/onboarding", "/phone-auth/**",
                                 "/auth/reissue").permitAll()
-                        .requestMatchers("/auth/fail").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/auth/fail", "/admin/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/auth/success", "/certification/**").hasAuthority("ROLE_STUDENT")
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/team/buddyya/common/service/S3UploadService.java
+++ b/src/main/java/com/team/buddyya/common/service/S3UploadService.java
@@ -6,7 +6,6 @@ import com.team.buddyya.common.exception.CommonException;
 import com.team.buddyya.common.exception.CommonExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -47,5 +46,14 @@ public class S3UploadService {
     private String generateFileName(MultipartFile file) {
         String fileName = UUID.randomUUID().toString() + "-" + file.getOriginalFilename();
         return fileName.replaceAll("\\s", "_");
+    }
+
+    public void deleteFile(String dir, String fileUrl) {
+        String fileName = extractFileName(fileUrl);
+        amazonS3.deleteObject(bucketName + dir, fileName);
+    }
+
+    private String extractFileName(String fileUrl) {
+        return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
     }
 }

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -66,8 +66,8 @@ public class Student extends BaseTime {
     @OneToOne(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private AuthToken authToken;
 
-    @OneToMany(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<StudentIdCard> studentIdCards;
+    @OneToOne(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private StudentIdCard studentIdCard;
 
     @Builder
     public Student(String name, String phoneNumber, String country, Boolean isKorean, Role role, University university, Gender gender) {

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -55,7 +55,7 @@ public class Student extends BaseTime {
     private Gender gender;
 
     @Column(name = "student_number")
-    private Integer studentNumber;
+    private String studentNumber;
 
     @OneToMany(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<StudentMajor> majors;
@@ -89,7 +89,7 @@ public class Student extends BaseTime {
         this.isCertificated = isCertificated;
     }
 
-    public void updateStudentNumber(Integer studentNumber) {
+    public void updateStudentNumber(String studentNumber) {
         this.studentNumber = studentNumber;
     }
 }

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -54,6 +54,9 @@ public class Student extends BaseTime {
     @Column(nullable = false)
     private Gender gender;
 
+    @Column(name = "student_number")
+    private Integer studentNumber;
+
     @OneToMany(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<StudentMajor> majors;
 
@@ -79,9 +82,14 @@ public class Student extends BaseTime {
         this.university = university;
         this.gender = gender;
         this.isCertificated = false;
+        this.studentNumber = null;
     }
 
     public void updateIsCertificated(boolean isCertificated) {
         this.isCertificated = isCertificated;
+    }
+
+    public void updateStudentNumber(Integer studentNumber) {
+        this.studentNumber = studentNumber;
     }
 }

--- a/src/main/java/com/team/buddyya/student/repository/StudentRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/StudentRepository.java
@@ -1,6 +1,5 @@
 package com.team.buddyya.student.repository;
 
-import com.team.buddyya.student.domain.Avatar;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.domain.University;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +10,5 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
 
     Optional<Student> findByPhoneNumber(String phoneNumber);
 
-    Optional<Student> findByStudentNumberAndUniversity(Integer studentNumber, University university);
+    Optional<Student> findByStudentNumberAndUniversity(String studentNumber, University university);
 }

--- a/src/main/java/com/team/buddyya/student/repository/StudentRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/StudentRepository.java
@@ -2,6 +2,7 @@ package com.team.buddyya.student.repository;
 
 import com.team.buddyya.student.domain.Avatar;
 import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.domain.University;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,6 @@ import java.util.Optional;
 public interface StudentRepository extends JpaRepository<Student, Long> {
 
     Optional<Student> findByPhoneNumber(String phoneNumber);
+
+    Optional<Student> findByStudentNumberAndUniversity(Integer studentNumber, University university);
 }

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -32,4 +32,14 @@ public class StudentService {
                 .build();
         return studentRepository.save(student);
     }
+
+    public boolean isDuplicateStudentNumber(Integer studentNumber, University university) {
+        return studentRepository.findByStudentNumberAndUniversity(studentNumber, university)
+                .isPresent();
+    }
+
+    public void updateStudentCertification(Student student, Integer studentNumber) {
+        student.updateIsCertificated(true);
+        student.updateStudentNumber(studentNumber);
+    }
 }

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -1,6 +1,9 @@
 package com.team.buddyya.student.service;
 
-import com.team.buddyya.student.domain.*;
+import com.team.buddyya.student.domain.Gender;
+import com.team.buddyya.student.domain.Role;
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.domain.University;
 import com.team.buddyya.student.dto.request.OnBoardingRequest;
 import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
@@ -33,12 +36,12 @@ public class StudentService {
         return studentRepository.save(student);
     }
 
-    public boolean isDuplicateStudentNumber(Integer studentNumber, University university) {
+    public boolean isDuplicateStudentNumber(String studentNumber, University university) {
         return studentRepository.findByStudentNumberAndUniversity(studentNumber, university)
                 .isPresent();
     }
 
-    public void updateStudentCertification(Student student, Integer studentNumber) {
+    public void updateStudentCertification(Student student, String studentNumber) {
         student.updateIsCertificated(true);
         student.updateStudentNumber(studentNumber);
     }


### PR DESCRIPTION
## 📌 관련 이슈
[관리자는 학생증 인증 승인, 혹은 반려[#21 ]](https://github.com/buddy-ya/be/issues/21)

<br><br>

## 🛠️ 작업 내용
- 관리자가 학생증 사진 목록을 조회하는 기능
- 관리자가 인증을 허가하면 인증된 회원으로 변경하는 기능

<br><br>

## 알아야 할 내용 💡
**`학생증 조회하는 api`**
```
return studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
                .map(StudentIdCardResponse::from)
                .collect(Collectors.toList());
```
다음과 같이 요청이 오래된 순으로 반환하도록 설계하였습니다

**`인증 승인, 반려 하는 api`**
```
public StudentVerificationResponse verifyStudentIdCard(StudentVerificationRequest request) {
        s3UploadService.deleteFile(STUDENT_ID_CARD.getDirectoryName(), request.imageUrl());
        Student student = studentRepository.findById(request.studentId())
                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
        studentIdCardRepository.deleteByStudent(student);
        if (request.studentNumber() == null) {
            return new StudentVerificationResponse(REQUEST_REJECTED_MESSAGE);
        }
        if (studentService.isDuplicateStudentNumber(request.studentNumber(), student.getUniversity())) {
            return new StudentVerificationResponse(ALREADY_REGISTERED_MESSAGE);
        }
        studentService.updateStudentCertification(student, request.studentNumber());
        return new StudentVerificationResponse(VERIFICATION_COMPLETED_MESSAGE);
    }
```
먼저 코드 흐름은 다음과 같습니다
1. 프론트에서 학생 `고유 번호(studentId)`, 인증하려는 `학번(studentNumber)`, `imageUrl`을 보냅니다
2. 일단 관리자가 한번 검증한 사진은 S3, 데이터베이스에서 모두 삭제합니다
3. 만약 studentNumber가 null이면 인증을 거절하는 것입니다. 따라서 `인증 요청이 거절되었습니다` 메세지를 보냅니다
4. 정상적인 studentNumber가 왔다면 요청한 학생의 학교와 학번으로 DB를 조회합니다(findByStudentNumberAndUniversity)
     -  이미 존재한다면 중복 학번으로 등록하려는 사용자이므로 `이미 등록된 학번입니다` 메세지를 보냅니다
     -  존재하지 않는다면 `isCertificated = true` 로 인증을 허가해주고 `학생 인증이 완료되었습니다` 메세지를 보냅니다


<br><br>
## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가?
- 예외처리가 빠진 부분은 없는가?
- 네이밍이 잘 지어졌는가? 
    - admin 관련된 api인데 학생증 목록을 조회하기 때문에 `StudentVerificationRequest`, `StudentIdCardListResponse`와 같이 dto를 작성하였는데 더 좋은 네이밍이 있는지 피드백 주시면 감사하겠습니다..!

## 🤔 고민한 점

재학생 인증을 허가 / 반려하는 부분에서 오류와 고민이 많았습니다

처음에 구현할 때는 `이미 등록된 학번입니다`를 throw new CertificateException()으로 ExceptionHandler로 예외를 처리하려고 했습니다.
이 방식으로 구현하니 다음과 같은 문제가 발생했습니다.

`S3에 대한 삭제` 요청은 Spring에서 트랜잭션과 독립적으로 처리되기 때문에 삭제되지만 `DB의 이미지 삭제`는 Transactional로 인한 Rollback이 되기 때문에 삭제가 되지 않습니다.
따라서 S3는 삭제됐지만 DB에는 URL이 그대로 남아있는 데이터 불일치가 발생하였습니다.

또한 `이미 존재하는 학번입니다` 는 정상적인 비즈니스 흐름의 일부라고 판단할 수 있습니다.
이미 존재하는 학번이면 서버에서 인증 상태를 변경해주지 않으면 되고, message로 상태만 알려주고 정상적인 응답 처리를 해주면 됩니다.

이런 문제를 반영하여 위와 같이 구현을 하였습니다. 
위와 같은 상황처럼 `오류 처리를 어떤 상황에서 해야하는가 `에 대해 얘기를 나눠보면 좋을 것 같습니다.

<br><br>

## 📎 커밋 범위 링크
https://github.com/buddy-ya/be/pull/25/files
<br><br>
