### PR TITLE
feat: 피드 검색 기능 구현

### DIFF
--- a/src/main/java/com/team/buddyya/common/DataLoader.java
+++ b/src/main/java/com/team/buddyya/common/DataLoader.java
@@ -1,19 +1,20 @@
 package com.team.buddyya.common;
 
 import com.team.buddyya.feed.domain.Category;
+import com.team.buddyya.feed.domain.Comment;
+import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.respository.CategoryRepository;
+import com.team.buddyya.feed.respository.CommentRepository;
+import com.team.buddyya.feed.respository.FeedRepository;
 import com.team.buddyya.student.controller.OnBoardingController;
-import com.team.buddyya.student.domain.Interest;
-import com.team.buddyya.student.domain.Language;
-import com.team.buddyya.student.domain.Major;
-import com.team.buddyya.student.domain.University;
+import com.team.buddyya.student.domain.*;
 import com.team.buddyya.student.dto.request.OnBoardingRequest;
 import com.team.buddyya.student.dto.response.OnBoardingResponse;
-import com.team.buddyya.student.repository.InterestRepository;
-import com.team.buddyya.student.repository.LanguageRepository;
-import com.team.buddyya.student.repository.MajorRepository;
-import com.team.buddyya.student.repository.UniversityRepository;
+import com.team.buddyya.student.repository.*;
+
 import java.util.List;
+import java.util.stream.IntStream;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +30,9 @@ public class DataLoader implements CommandLineRunner {
     private final UniversityRepository universityRepository;
     private final OnBoardingController onBoardingController;
     private final CategoryRepository categoryRepository;
+    private final FeedRepository feedRepository;
+    private final CommentRepository commentRepository;
+    private final StudentRepository studentRepository;
 
     @Override
     public void run(String... args) throws Exception {
@@ -38,6 +42,7 @@ public class DataLoader implements CommandLineRunner {
         loadUniversities();
         createMockStudents();
         loadCategories();
+        createMockFeedsAndComments();
     }
 
     private void loadMajors() {
@@ -124,4 +129,71 @@ public class DataLoader implements CommandLineRunner {
             }
         });
     }
+
+    private void createMockFeedsAndComments() {
+        Student student = studentRepository.findAll().get(0);
+        Category category = categoryRepository.findAll().get(0);
+        List<Feed> mockFeeds = List.of(
+                Feed.builder()
+                        .title("학냥이 너무 귀여운 것 같아")
+                        .content("잘 찍었지? 학냥이가 너무너무 좋아. 잔디밭에서 뒹구는 것 봐 ㅎㅎㅎ")
+                        .student(student)
+                        .category(category)
+                        .university(student.getUniversity())
+                        .build(),
+                Feed.builder()
+                        .title("글글글 글글 글글 글")
+                        .content("맥주랑 크키카칵\n카스다카스다 어쩌고 ...")
+                        .student(student)
+                        .category(category)
+                        .university(student.getUniversity())
+                        .build(),
+                Feed.builder()
+                        .title("영국 맨체스터 대학교 교환학생 후기")
+                        .content("안녕하세요! 저는 이번에 맨체스터 대학교에서 한 학기를 보내고 왔습니다. 정말 값진 경험이었어요...")
+                        .student(student)
+                        .category(category)
+                        .university(student.getUniversity())
+                        .build()
+        );
+        mockFeeds.forEach(feed -> feedRepository.save(feed));
+        List<Comment> mockComments = List.of(
+                Comment.builder()
+                        .content("와 대박 ㅋㅋ 나도 학교 고양이 좋아하는데!")
+                        .feed(mockFeeds.get(0))
+                        .student(student)
+                        .build(),
+                Comment.builder()
+                        .content("우리 학교 근처에도 있어요")
+                        .feed(mockFeeds.get(0))
+                        .student(student)
+                        .build(),
+                Comment.builder()
+                        .content("귀엽다 ㅎㅎ")
+                        .feed(mockFeeds.get(0))
+                        .student(student)
+                        .build()
+        );
+        mockComments.forEach(comment -> commentRepository.save(comment));
+        IntStream.range(0, 15).forEach(i -> {
+            Feed feed = Feed.builder()
+                    .title("Sample Feed Title " + i)
+                    .content("Sample Feed Content " + i)
+                    .student(student)
+                    .category(category)
+                    .university(student.getUniversity())
+                    .build();
+            feedRepository.save(feed);
+
+            IntStream.range(0, 15).forEach(j -> {
+                Comment comment = Comment.builder()
+                        .content("Sample Comment " + j + " for Feed " + i)
+                        .feed(feed)
+                        .student(student)
+                        .build();
+                commentRepository.save(comment);
+            });
+        });
+    }
+
 }

--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -14,15 +14,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController

--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
@@ -8,6 +8,7 @@ public record CommentResponse(
         String content,
         String name,
         String country,
+        String university,
         LocalDateTime createdDate,
         boolean isFeedOwner,
         boolean isCommentOwner
@@ -19,6 +20,7 @@ public record CommentResponse(
                 info.comment().getContent(),
                 info.comment().getStudent().getName(),
                 info.comment().getStudent().getCountry(),
+                info.comment().getStudent().getUniversity().getUniversityName(),
                 info.comment().getCreatedDate(),
                 info.isFeedOwner(),
                 info.isCommentOwner()

--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -12,6 +12,7 @@ public record FeedResponse(
         String country,
         String title,
         String content,
+        String university,
         List<String> imageUrls,
         int likeCount,
         int commentCount,
@@ -28,6 +29,7 @@ public record FeedResponse(
                 feed.getStudent().getCountry(),
                 feed.getTitle(),
                 feed.getContent(),
+                feed.getStudent().getUniversity().getUniversityName(),
                 feed.getImages().stream()
                         .map(FeedImage::getUrl)
                         .toList(),

--- a/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     Page<Feed> findAllByCategoryName(String category, Pageable pageable);
+
+    Page<Feed> findByTitleContainingOrContentContaining(String titleQuery, String contentQuery, Pageable pageable);
 }

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -112,7 +112,6 @@ public class FeedService {
         return feedRepository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
     }
 
-
     private void validateFeedOwner(Long studentId, Feed feed) {
         if (!studentId.equals(feed.getStudent().getId())) {
             throw new FeedException(FeedExceptionType.NOT_FEED_OWNER);

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -47,13 +47,18 @@ public class FeedService {
     }
 
     public FeedListResponse getFeeds(StudentInfo studentInfo, Pageable pageable, FeedListRequest request) {
-        Category category = categoryService.getCategory(request.category());
-        Pageable customPageable = PageRequest.of(
-                pageable.getPageNumber(),
-                pageable.getPageSize(),
-                getSortBy(category)
-        );
-        Page<Feed> feeds = feedRepository.findAllByCategoryName(category.getName(), customPageable);
+        Page<Feed> feeds;
+        if (request.keyword() == null || request.keyword().isBlank()) {
+            Category category = categoryService.getCategory(request.category());
+            Pageable customPageable = PageRequest.of(
+                    pageable.getPageNumber(),
+                    pageable.getPageSize(),
+                    getSortBy(category)
+            );
+            feeds = feedRepository.findAllByCategoryName(category.getName(), customPageable);
+        } else {
+            feeds = feedRepository.findByTitleContainingOrContentContaining(request.keyword(), request.keyword(), pageable);
+        }
         List<FeedResponse> response = feeds.getContent().stream()
                 .map(feed -> createFeedResponse(feed, studentInfo.id()))
                 .toList();


### PR DESCRIPTION
## 📌 관련 이슈
[피드 기능 개발 #22](https://github.com/buddy-ya/be/issues/22)

## 🛠️ 작업 내용
- feedListRequest의 keyword를 사용하여 검색기능 추가
- feedResponse DTO에 글 작성자의 학교 추가
- commentResponse DTO에 댓글 작성자의 학교 추가
- 피드와 댓글 목데이터 추가

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션은 잘 지켜졌나요?
- 검색 및 getfeeds에서 필요한 예외가 있나요?

## 🤔 고민한 점
코드를 보시면 
- 검색값이 없을때(keyword가 null 혹은 blank)는 카테고리 구분하여 조회하여 반환
- 검색값이 있을때는 카테고리는 구분하지 않고 피드의 제목과 내용에서만 조회하여 피드들 반환

현재는 검색에서는 카테고리를  구분하지 않고 조회하는데
카테고리를 구분하고 싶으면 카테고리를 구분하지 않을 때 추가적인 로직이 필요합니다.
- category에 '전체'를 추가 혹은 null로 표시
- 서버에서 category가 '전체' 혹은 null일때는 카테고리를 구분하지 않고
전체 피드에서 검색하여 피드들 반환

**카테고리별로 검색하는 것을 추가하는 것이 좋을까요?**
<br><br>

## 📎 커밋 범위 링크

<br><br>
