### PR TITLE
feat: 학생 기본 프로필 추가

### DIFF
--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentCreateResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentCreateResponse.java
@@ -9,6 +9,7 @@ public record CommentCreateResponse(
         String name,
         String country,
         String university,
+        String profileImageUrl,
         LocalDateTime createdDate,
         boolean isFeedOwner,
         boolean isCommentOwner
@@ -21,6 +22,7 @@ public record CommentCreateResponse(
                 info.comment().getStudent().getName(),
                 info.comment().getStudent().getCountry(),
                 info.comment().getStudent().getUniversity().getUniversityName(),
+                info.comment().getStudent().getProfileImage().getUrl(),
                 info.comment().getCreatedDate(),
                 info.isFeedOwner(),
                 info.isCommentOwner()

--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
@@ -9,6 +9,7 @@ public record CommentResponse(
         String name,
         String country,
         String university,
+        String profileImageUrl,
         LocalDateTime createdDate,
         boolean isFeedOwner,
         boolean isCommentOwner
@@ -21,6 +22,7 @@ public record CommentResponse(
                 info.comment().getStudent().getName(),
                 info.comment().getStudent().getCountry(),
                 info.comment().getStudent().getUniversity().getUniversityName(),
+                info.comment().getStudent().getProfileImage().getUrl(),
                 info.comment().getCreatedDate(),
                 info.isFeedOwner(),
                 info.isCommentOwner()

--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentUpdateResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentUpdateResponse.java
@@ -10,6 +10,7 @@ public record CommentUpdateResponse(
         String name,
         String country,
         String university,
+        String profileImageUrl,
         LocalDateTime updateTime,
         boolean isFeedOwner,
         boolean isCommentOwner
@@ -22,6 +23,7 @@ public record CommentUpdateResponse(
                 info.comment().getStudent().getName(),
                 info.comment().getStudent().getCountry(),
                 info.comment().getStudent().getUniversity().getUniversityName(),
+                info.comment().getStudent().getProfileImage().getUrl(),
                 info.comment().getUpdatedDate(),
                 info.isFeedOwner(),
                 info.isCommentOwner()

--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -13,6 +13,7 @@ public record FeedResponse(
         String title,
         String content,
         String university,
+        String profileImageUrl,
         List<String> imageUrls,
         int likeCount,
         int commentCount,
@@ -30,6 +31,7 @@ public record FeedResponse(
                 feed.getTitle(),
                 feed.getContent(),
                 feed.getStudent().getUniversity().getUniversityName(),
+                feed.getStudent().getProfileImage().getUrl(),
                 feed.getImages().stream()
                         .map(FeedImage::getUrl)
                         .toList(),

--- a/src/main/java/com/team/buddyya/student/controller/MyPageController.java
+++ b/src/main/java/com/team/buddyya/student/controller/MyPageController.java
@@ -56,4 +56,11 @@ public class MyPageController {
                                                             @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(feedService.getBookmarkFeed(userDetails.getStudentInfo(), pageable));
     }
+
+    @PostMapping("/update/profile-default-image")
+    public ResponseEntity<MyPageUpdateResponse> updateProfileDefaultImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam String profileImageKey) {
+        return ResponseEntity.ok(myPageService.updateProfileDefaultImage(userDetails.getStudentInfo(), profileImageKey));
+    }
 }

--- a/src/main/java/com/team/buddyya/student/domain/ProfileDefaultImage.java
+++ b/src/main/java/com/team/buddyya/student/domain/ProfileDefaultImage.java
@@ -1,0 +1,38 @@
+package com.team.buddyya.student.domain;
+
+import com.team.buddyya.student.exception.StudentException;
+import com.team.buddyya.student.exception.StudentExceptionType;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum ProfileDefaultImage {
+    PROFILE_DEFAULT_IMAGE_1("image1", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image1.png"),
+    PROFILE_DEFAULT_IMAGE_2("image2", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image2.png"),
+    PROFILE_DEFAULT_IMAGE_3("image3", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image3.png"),
+    PROFILE_DEFAULT_IMAGE_4("image4", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image4.png"),
+    PROFILE_DEFAULT_IMAGE_5("image5", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image5.png"),
+    PROFILE_DEFAULT_IMAGE_6("image6", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image6.png");
+
+    private final String key;
+    private final String url;
+
+    ProfileDefaultImage(String key, String url) {
+        this.key = key;
+        this.url = url;
+    }
+
+    public static ProfileDefaultImage getRandomProfileImage() {
+        ProfileDefaultImage[] values = ProfileDefaultImage.values();
+        return values[(int) (Math.random() * values.length)];
+    }
+
+    public static ProfileDefaultImage fromValue(String key) {
+        return Arrays.stream(ProfileDefaultImage.values())
+                .filter(image -> image.key.equals(key))
+                .findFirst()
+                .orElseThrow(() -> new StudentException(StudentExceptionType.INVALID_DEFAULT_IMAGE_KEY));
+    }
+}
+

--- a/src/main/java/com/team/buddyya/student/domain/ProfileImage.java
+++ b/src/main/java/com/team/buddyya/student/domain/ProfileImage.java
@@ -1,0 +1,37 @@
+package com.team.buddyya.student.domain;
+
+import com.team.buddyya.common.domain.CreatedTime;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "profile_image")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ProfileImage extends CreatedTime {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @Column(length = 255, nullable = false)
+    private String url;
+
+    @Builder
+    public ProfileImage(Student student, String url) {
+        this.student = student;
+        this.url = url;
+    }
+
+    public void updateUrl(String newUrl) {
+        this.url = newUrl;
+    }
+}

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -70,6 +70,9 @@ public class Student extends BaseTime {
     private List<StudentInterest> interests;
 
     @OneToOne(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private ProfileImage profileImage;
+
+    @OneToOne(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private AuthToken authToken;
 
     @OneToOne(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/src/main/java/com/team/buddyya/student/dto/response/MyPageResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/MyPageResponse.java
@@ -10,6 +10,7 @@ public record MyPageResponse(
         String country,
         String university,
         String gender,
+        String profileImageUrl,
         List<String> majors,
         List<String> languages,
         List<String> interests
@@ -21,6 +22,7 @@ public record MyPageResponse(
                 student.getCountry(),
                 student.getUniversity().getUniversityName(),
                 student.getGender().getDisplayName(),
+                student.getProfileImage().getUrl(),
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests())

--- a/src/main/java/com/team/buddyya/student/exception/StudentExceptionType.java
+++ b/src/main/java/com/team/buddyya/student/exception/StudentExceptionType.java
@@ -10,7 +10,9 @@ public enum StudentExceptionType implements BaseExceptionType {
     MAJOR_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당 전공을 찾지 못하였습니다."),
     LANGUAGE_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당 언어를 찾지 못하였습니다."),
     INTEREST_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당 관심사를 찾지 못하였습니다."),
-    INVALID_GENDER_VALUE(2000, HttpStatus.BAD_REQUEST, "유효하지 않은 성별 값입니다.");
+    PROFILE_IMAGE_NOT_FOUND(2000, HttpStatus.NOT_FOUND, "해당 학생의 프로필 이미지를 찾지 못하였습니다."),
+    INVALID_GENDER_VALUE(2000, HttpStatus.BAD_REQUEST, "유효하지 않은 성별 값입니다."),
+    INVALID_DEFAULT_IMAGE_KEY(2000, HttpStatus.BAD_REQUEST, "유효하지 않은 프로필 이미지 키값입니다.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/student/repository/ProfileImageRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/ProfileImageRepository.java
@@ -1,0 +1,14 @@
+package com.team.buddyya.student.repository;
+
+import com.team.buddyya.student.domain.ProfileImage;
+import com.team.buddyya.student.domain.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+    Optional<ProfileImage> findByStudent(Student student);
+}
+

--- a/src/main/java/com/team/buddyya/student/service/MyPageService.java
+++ b/src/main/java/com/team/buddyya/student/service/MyPageService.java
@@ -21,6 +21,7 @@ public class MyPageService {
     private final StudentInterestService studentInterestService;
     private final StudentLanguageService studentLanguageService;
     private final StudentService studentService;
+    private final ProfileImageService profileImageService;
 
     public MyPageUpdateResponse updateInterests(StudentInfo studentInfo, MyPageUpdateInterestsRequest request) {
         Student student = studentService.findByStudentId(studentInfo.id());
@@ -37,6 +38,12 @@ public class MyPageService {
     public MyPageUpdateResponse updateName(StudentInfo studentInfo, MyPageUpdateNameRequest request) {
         Student student = studentService.findByStudentId(studentInfo.id());
         student.updateName(request.name());
+        return MyPageUpdateResponse.from(UPDATE_SUCCESS_MESSAGE);
+    }
+
+    public MyPageUpdateResponse updateProfileDefaultImage(StudentInfo studentInfo, String profileImageKey) {
+        Student student = studentService.findByStudentId(studentInfo.id());
+        profileImageService.updateProfileDefaultImage(student, profileImageKey);
         return MyPageUpdateResponse.from(UPDATE_SUCCESS_MESSAGE);
     }
 

--- a/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
+++ b/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
@@ -21,6 +21,7 @@ public class OnBoardingService {
     private final StudentInterestService studentInterestService;
     private final StudentLanguageService studentLanguageService;
     private final StudentMajorService studentMajorService;
+    private final ProfileImageService profileImageService;
     private final AuthTokenRepository authTokenRepository;
     private final JwtUtils jwtUtils;
 
@@ -28,6 +29,7 @@ public class OnBoardingService {
         Student student = studentService.createStudent(request);
         String accessToken = jwtUtils.createAccessToken(new TokenInfoRequest(student.getId()));
         String refreshToken = createAndSaveToken(student);
+        profileImageService.saveRandomProfileImage(student);
         avatarService.createAvatar(request, student);
         studentMajorService.createStudentMajors(request.majors(), student);
         studentInterestService.createStudentInterests(request.interests(), student);

--- a/src/main/java/com/team/buddyya/student/service/ProfileImageService.java
+++ b/src/main/java/com/team/buddyya/student/service/ProfileImageService.java
@@ -24,6 +24,12 @@ public class ProfileImageService {
         profileImageRepository.save(profileImage);
     }
 
+    public void updateProfileDefaultImage(Student student, String profileImageKey) {
+        ProfileDefaultImage defaultImage = ProfileDefaultImage.fromValue(profileImageKey);
+        ProfileImage profileImage = findProfileImageByStudent(student);
+        profileImage.updateUrl(defaultImage.getUrl());
+    }
+
     public ProfileImage findProfileImageByStudent(Student student){
         return profileImageRepository.findByStudent(student)
                 .orElseThrow(() -> new StudentException(StudentExceptionType.PROFILE_IMAGE_NOT_FOUND));

--- a/src/main/java/com/team/buddyya/student/service/ProfileImageService.java
+++ b/src/main/java/com/team/buddyya/student/service/ProfileImageService.java
@@ -1,0 +1,32 @@
+package com.team.buddyya.student.service;
+
+import com.team.buddyya.student.domain.ProfileDefaultImage;
+import com.team.buddyya.student.domain.ProfileImage;
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.exception.StudentException;
+import com.team.buddyya.student.exception.StudentExceptionType;
+import com.team.buddyya.student.repository.ProfileImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileImageService {
+
+    private final ProfileImageRepository profileImageRepository;
+
+    public void saveRandomProfileImage(Student student) {
+        ProfileDefaultImage randomImage = ProfileDefaultImage.getRandomProfileImage();
+        ProfileImage profileImage = ProfileImage.builder()
+                .student(student)
+                .url(randomImage.getUrl())
+                .build();
+        profileImageRepository.save(profileImage);
+    }
+
+    public ProfileImage findProfileImageByStudent(Student student){
+        return profileImageRepository.findByStudent(student)
+                .orElseThrow(() -> new StudentException(StudentExceptionType.PROFILE_IMAGE_NOT_FOUND));
+    }
+}
+


### PR DESCRIPTION
## 📌 관련 이슈
[학생 프로필 추가](https://github.com/buddy-ya/be/issues/35)[#35]

<br><br>

## 🛠️ 작업 내용
- 학생의 프로필 이미지를 저장할 profile-image 엔티티(테이블) 추가
- 온보딩시 학생에게 기본프로필(현재6개)중에 하나 정해주는 로직 추가 
- 마이페이지에서 기본 프로필 수정 API 생성
- 댓글,피드,마이페이지의 Response DTO에 프로필 이미지 URL 추가 

<br><br>

## 🎯 리뷰 포인트

- 코드 컨벤션은 잘 지켜졌는가?
- 빠진 예외처리는 없는가?
- 추가적으로 필요한 프로필 관련 서비스가 있을까?

### 알아야할 부분 🤓 
- 프로필을 변경할때 프론트에서 쿼리문으로 바꾸고 싶은 기본이미지를 
키값(image1~image6)으로 넘겨줘야한다. 
-> `/mypage/update/profile-default-image?profileImageKey={imageN}`

- 추가적으로 기본 프로필이 아닌 다른 이미지를 사용하고 싶으면 추가적인 api가 필요하다.
예시) `/mypage/update/profile-image` `@ModelAttribute ProfileImageUpdateRequest `
아직 프론트/기획과 기본 프로필이 아닌 다른 이미지로 프로필 사용이 얘기되지 않아서
필요 시 api를 만들면 될 거 같다.

### 고민한 점 🤔 
`ProfileImageService`에서 `updateProfileDefaultImage` 메서드를 보시면 profileImage를 `student.getProfileImage()`가 아닌
`ProfileImageRepository`에서 `student`를 이용해서 조회하고 찾지 못하면 예외를 터뜨리는 방식을 채택하였습니다.
어떤 것이 더 나은 방식이라고 생각하시는지 궁금합니다.   
 ```
   public void updateProfileDefaultImage(Student student, String profileImageKey) {
        ProfileDefaultImage defaultImage = ProfileDefaultImage.fromValue(profileImageKey);
        ProfileImage profileImage = findProfileImageByStudent(student);
        profileImage.updateUrl(defaultImage.getUrl());
    }
```


<br><br>

## 📎 커밋 범위 링크

<br><br>
