### PR TITLE
feat: 좋아요 10개 이상 피드 조회

### DIFF
--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -30,11 +30,17 @@ public class FeedController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/popular")
+    public ResponseEntity<FeedListResponse> getPopularFeeds(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                            @PageableDefault(size = 10, sort = "createdDate", direction = Direction.DESC) Pageable pageable) {
+        FeedListResponse response = feedService.getPopularFeeds(userDetails.getStudentInfo(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping
     public ResponseEntity<Void> createFeed(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @ModelAttribute FeedCreateRequest request) {
-        System.out.println("request : " + request.category() + " " + request.title() + " " + request.content());
         feedService.createFeed(userDetails.getStudentInfo(), request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
@@ -15,4 +15,6 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     Page<Feed> findAllByStudent(Student student, Pageable pageable);
 
     Page<Feed> findByTitleContainingOrContentContaining(String titleQuery, String contentQuery, Pageable pageable);
+
+    Page<Feed> findByLikeCountGreaterThanEqual(int likeCount, Pageable pageable);
 }

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -32,6 +32,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FeedService {
 
+    private static final int LIKE_COUNT_THRESHOLD = 10;
+
     private final CategoryService categoryService;
     private final FeedRepository feedRepository;
     private final StudentRepository studentRepository;
@@ -54,6 +56,14 @@ public class FeedService {
             return FeedListResponse.from(response, feeds);
         }
         Page<Feed> feeds = fetchFeedsByKeyword(keyword, pageable);
+        List<FeedResponse> response = feeds.getContent().stream()
+                .map(feed -> createFeedResponse(feed, studentInfo.id()))
+                .toList();
+        return FeedListResponse.from(response, feeds);
+    }
+
+    public FeedListResponse getPopularFeeds(StudentInfo studentInfo, Pageable pageable) {
+        Page<Feed> feeds = feedRepository.findByLikeCountGreaterThanEqual(LIKE_COUNT_THRESHOLD, pageable);
         List<FeedResponse> response = feeds.getContent().stream()
                 .map(feed -> createFeedResponse(feed, studentInfo.id()))
                 .toList();


### PR DESCRIPTION
## 📌 관련 이슈
[피드 좋아요 순으로 조회[#39 ]](https://github.com/buddy-ya/be/issues/39)
<br><br>

## 🛠️ 작업 내용
- 좋아요 10개 이상인 피드를 최신 순으로 정렬하여 조회하는 기능

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가?
- 예외처리가 빠진 부분은 없는가?
<br><br>

## 💡알아야할 부분 
JPA의 쿼리 메서드 `findByLikeCountGreaterThanEqual(int likeCount, Pageable pageable)`를 사용하여 좋아요 10개 이상인 피드를 조회하였습니다
pageble의 getSort()를 활용하여 최신 순으로 내림차순 정렬을 하였습니다

## 고민한 점 🤔
처음에 pageable의 속성을 활용하지 않고 `findByLikeCountGreaterThanEqualOrderByCreatedDateDesc`으로 사용하려다가 쿼리 메서드가 길어졌습니다.
이번에는 pageble의 속성으로 `OrderByCreatedDateDesc`를 해결하여 쿼리 메서드를 사용하였는데 보통 2개 조건까지는 쿼리 메서드를 많이 사용하고 3개 이상부터는 @Query의 JPQL을 작성하여 해결한다고 합니다! 쿼리 메서드 길어지면 사용해봐도 좋을 것 같아요!
[JPA 쿼리 메서드 길어질 때](https://blogshine.tistory.com/389)

## 📎 커밋 범위 링크
https://github.com/buddy-ya/be/pull/40/files
<br><br>
