### PR TITLE
fix : feed 수정 시 기존 이미지 중복 업데이트 오류 수정 & 프로필 수정 POST->PATCH

### DIFF
--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -55,7 +55,6 @@ public class FeedController {
         return ResponseEntity.ok().build();
     }
 
-
     @DeleteMapping("/{feedId}")
     public ResponseEntity<Void> deleteFeed(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -101,7 +101,7 @@ public class Feed extends BaseTime {
         this.commentCount--;
     }
 
-    public void uploadFeedImage(FeedImage image) {
-        this.images.add(image);
+    public void uploadFeedImages(List<FeedImage> images) {
+        this.images= images;
     }
 }

--- a/src/main/java/com/team/buddyya/feed/respository/FeedImageRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/FeedImageRepository.java
@@ -1,9 +1,12 @@
 package com.team.buddyya.feed.respository;
 
+import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.domain.FeedImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
+
+    void deleteByFeed(Feed feed);
 }

--- a/src/main/java/com/team/buddyya/feed/service/FeedImageService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedImageService.java
@@ -20,17 +20,25 @@ public class FeedImageService {
     private final S3UploadService s3UploadService;
     private final FeedImageRepository feedImageRepository;
 
-    public List<FeedImage> uploadFeedImages(Feed feed, List<MultipartFile> images) {
+    public void uploadFeedImages(List<FeedImage> images){
+        feedImageRepository.saveAll(images);
+    }
+
+    public void deleteFeedImages(Feed feed){
+        feedImageRepository.deleteByFeed(feed);
+    }
+
+    public List<FeedImage> uploadS3FeedImages(Feed feed, List<MultipartFile> images) {
         if (images == null || images.isEmpty()) {
             return List.of();
         }
         return images.stream()
                 .filter(this::isValidImageFile)
-                .map(image -> uploadFeedImage(feed, image))
+                .map(image -> uploadS3FeedImage(feed, image))
                 .toList();
     }
 
-    public void deleteFeedImages(Feed feed) {
+    public void deleteS3FeedImages(Feed feed) {
         feed.getImages()
                 .forEach(feedImage -> s3UploadService.deleteFile(FEED_IMAGE.getDirectoryName(), feedImage.getUrl()));
     }
@@ -39,7 +47,7 @@ public class FeedImageService {
         return image != null && !image.isEmpty();
     }
 
-    private FeedImage uploadFeedImage(Feed feed, MultipartFile image) {
+    private FeedImage uploadS3FeedImage(Feed feed, MultipartFile image) {
         String imageUrl = s3UploadService.uploadFile(S3DirectoryName.FEED_IMAGE.getDirectoryName(), image);
         FeedImage feedImage = FeedImage.builder()
                 .feed(feed)

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -85,13 +85,13 @@ public class FeedService {
         validateFeedOwner(studentInfo.id(), feed);
         Category category = categoryService.getCategory(request.category());
         feed.updateFeed(request.title(), request.content(), category);
-        uploadImages(feed, request.images());
+        updateImages(feed, request.images());
     }
 
     public void deleteFeed(StudentInfo studentInfo, Long feedId) {
         Feed feed = findFeedByFeedId(feedId);
         validateFeedOwner(studentInfo.id(), feed);
-        feedImageService.deleteFeedImages(feed);
+        feedImageService.deleteS3FeedImages(feed);
         feedRepository.delete(feed);
     }
 
@@ -127,10 +127,19 @@ public class FeedService {
         return FeedUserAction.of(isFeedOwner, isLiked, isBookmarked);
     }
 
+    private void updateImages(Feed feed, List<MultipartFile> images) {
+        feedImageService.deleteFeedImages(feed);
+        feedImageService.deleteS3FeedImages(feed);
+        if (images != null && !images.isEmpty()) {
+            List<FeedImage> feedImages = feedImageService.uploadS3FeedImages(feed, images);
+            feedImageService.uploadFeedImages(feedImages);
+        }
+    }
+
     private void uploadImages(Feed feed, List<MultipartFile> images) {
         if (images != null && !images.isEmpty()) {
-            List<FeedImage> feedImages = feedImageService.uploadFeedImages(feed, images);
-            feedImages.forEach(feed::uploadFeedImage);
+            List<FeedImage> feedImages = feedImageService.uploadS3FeedImages(feed, images);
+            feed.uploadFeedImages(feedImages);
         }
     }
 

--- a/src/main/java/com/team/buddyya/student/controller/MyPageController.java
+++ b/src/main/java/com/team/buddyya/student/controller/MyPageController.java
@@ -57,7 +57,7 @@ public class MyPageController {
         return ResponseEntity.ok(feedService.getBookmarkFeed(userDetails.getStudentInfo(), pageable));
     }
 
-    @PostMapping("/update/profile-default-image")
+    @PatchMapping("/update/profile-default-image")
     public ResponseEntity<MyPageUpdateResponse> updateProfileDefaultImage(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam String profileImageKey) {

--- a/src/main/java/com/team/buddyya/student/domain/ProfileImage.java
+++ b/src/main/java/com/team/buddyya/student/domain/ProfileImage.java
@@ -14,6 +14,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class ProfileImage extends CreatedTime {
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;

--- a/src/main/java/com/team/buddyya/student/repository/ProfileImageRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/ProfileImageRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 @Repository
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+
     Optional<ProfileImage> findByStudent(Student student);
 }
 

--- a/src/main/java/com/team/buddyya/student/service/ProfileImageService.java
+++ b/src/main/java/com/team/buddyya/student/service/ProfileImageService.java
@@ -26,13 +26,8 @@ public class ProfileImageService {
 
     public void updateProfileDefaultImage(Student student, String profileImageKey) {
         ProfileDefaultImage defaultImage = ProfileDefaultImage.fromValue(profileImageKey);
-        ProfileImage profileImage = findProfileImageByStudent(student);
+        ProfileImage profileImage = student.getProfileImage();
         profileImage.updateUrl(defaultImage.getUrl());
-    }
-
-    public ProfileImage findProfileImageByStudent(Student student){
-        return profileImageRepository.findByStudent(student)
-                .orElseThrow(() -> new StudentException(StudentExceptionType.PROFILE_IMAGE_NOT_FOUND));
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
[ feed 수정 시 기존 이미지 중복 업데이트 오류 수정](https://github.com/buddy-ya/be/issues/41)[#41]
[학생 프로필 추가](https://github.com/buddy-ya/be/issues/35)[#35]

## 🛠️ 작업 내용
-  feed 수정 시 기존 이미지 중복 업데이트 오류 수정
-  프로필 수정 POST->PATCH
-  프로필을 ProfileImageRepository로 직접 조회 -> Student.getProfileImage()로 조회
- 데이터베이스에 이미지를 저장하는 메서드와 S3에 이미지를 저장하는 메서드가 잘 구분이 되지않아
메서드명을 조금 더 명확히 해보았습니다

<br><br>

## 🎯 리뷰 포인트

- 코드 컨벤션은 잘 지켜졌나요?
- 현재 이미지를 업데이트 하는 로직이 괜찮다고 생각하시나요?

### 고민한점 🤔 
업데이트시 해당 피드의 이미지를 모두 삭제한후 다시 새로운 이미지를 저장하는 로직으로 변경하였습니다.

원래는 Feed 엔티티 안에 있는 
```
public void uploadFeedImages(List<FeedImage> images) {
        this.images= images;
    }
```
를 사용해서 새로운 이미지들을 다시 저장하려고 했으나. 그렇게 하니 오류가 생겨 
FeedImageRepository를 사용해서 저장하였습니다.

추후에 왜 문제가 생기는지 알아봐야할 거 같습니다.

<br><br>

## 📎 커밋 범위 링크

<br><br>
