### PR TITLE
feat: 댓글 업데이트 시 생성 날짜 같이 반환

### DIFF
--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentUpdateResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentUpdateResponse.java
@@ -1,6 +1,7 @@
 package com.team.buddyya.feed.dto.response.comment;
 
 import com.team.buddyya.feed.domain.CommentInfo;
+
 import java.time.LocalDateTime;
 
 
@@ -11,7 +12,8 @@ public record CommentUpdateResponse(
         String country,
         String university,
         String profileImageUrl,
-        LocalDateTime updateTime,
+        LocalDateTime updatedDate,
+        LocalDateTime createdDate,
         boolean isFeedOwner,
         boolean isCommentOwner
 ) {
@@ -25,6 +27,7 @@ public record CommentUpdateResponse(
                 info.comment().getStudent().getUniversity().getUniversityName(),
                 info.comment().getStudent().getProfileImage().getUrl(),
                 info.comment().getUpdatedDate(),
+                info.comment().getCreatedDate(),
                 info.isFeedOwner(),
                 info.isCommentOwner()
         );


### PR DESCRIPTION
## 📌 관련 이슈
[댓글 업데이트 시 댓글에 날짜 추가[#43 ]](https://github.com/buddy-ya/be/issues/43)
<br><br>

## 🛠️ 작업 내용
댓글 수정 시 생성 날짜 같이 반환하도록 수정하였습니다
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
