### PR TITLE
test: mypage 학생 정보 조회 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,53 +1,57 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.11'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.11'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.team'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
-	maven {url 'https://jitpack.io'}
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-	// 대학 메일 인증 univcert
-	implementation 'com.github.in-seo:univcert:master-SNAPSHOT'
-	// 문자 인증 nurigo
-	implementation 'net.nurigo:sdk:4.2.7'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    // 대학 메일 인증 univcert
+    implementation 'com.github.in-seo:univcert:master-SNAPSHOT'
+    // 문자 인증 nurigo
+    implementation 'net.nurigo:sdk:4.2.7'
 
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
-	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'net.nurigo:sdk:4.2.7'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    //junit test
+    testImplementation 'org.assertj:assertj-core:3.24.2'
+    //test시 인메모리 db h2 tkdud
+    testImplementation 'com.h2database:h2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'net.nurigo:sdk:4.2.7'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/test/java/com/team/buddyya/student/service/MyPageServiceTest.java
+++ b/src/test/java/com/team/buddyya/student/service/MyPageServiceTest.java
@@ -1,0 +1,78 @@
+package com.team.buddyya.student.service;
+
+import com.team.buddyya.auth.domain.StudentInfo;
+import com.team.buddyya.student.domain.*;
+import com.team.buddyya.student.dto.response.MyPageResponse;
+import com.team.buddyya.student.repository.StudentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MyPageServiceTest {
+
+    @InjectMocks
+    private MyPageService myPageService;
+
+    @Mock
+    private StudentService studentService;
+
+    @Mock
+    private StudentRepository studentRepository;
+
+    private Student mockStudent;
+
+    @BeforeEach
+    void setUp() {
+        // Mock 객체 생성
+        University mockUniversity = mock(University.class);
+        when(mockUniversity.getUniversityName()).thenReturn("sju");
+
+        ProfileImage mockProfileImage = mock(ProfileImage.class);
+        when(mockProfileImage.getUrl()).thenReturn("http://mock-image.com/profile.jpg");
+
+        mockStudent = mock(Student.class);
+        when(mockStudent.getName()).thenReturn("Hong gildong");
+        when(mockStudent.getPhoneNumber()).thenReturn("01012345678");
+        when(mockStudent.getCountry()).thenReturn("ko");
+        when(mockStudent.getIsKorean()).thenReturn(true);
+        when(mockStudent.getRole()).thenReturn(Role.STUDENT);
+        when(mockStudent.getUniversity()).thenReturn(mockUniversity);
+        when(mockStudent.getGender()).thenReturn(Gender.MALE);
+
+        // 빈 리스트 설정
+        when(mockStudent.getMajors()).thenReturn(List.of());
+        when(mockStudent.getLanguages()).thenReturn(List.of());
+        when(mockStudent.getInterests()).thenReturn(List.of());
+        when(mockStudent.getProfileImage()).thenReturn(mockProfileImage);
+
+        // StudentService Mock 설정
+        when(studentService.findByStudentId(1L)).thenReturn(mockStudent);
+    }
+
+    @Test
+    void 마이페이지_학생_정보를_조회한다() {
+        // Given
+        StudentInfo studentInfo = new StudentInfo(1L, Role.STUDENT, true);
+
+        // When
+        MyPageResponse response = myPageService.getMyPage(studentInfo);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo("Hong gildong");
+        assertThat(response.country()).isEqualTo("ko");
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,9 @@
+# H2 in-memory database ??
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+# ??? ?? ???
+spring.profiles.active=test


### PR DESCRIPTION
## 📌 관련 이슈
[Mypage 테스트 [#45 ]](https://github.com/buddy-ya/be/issues/45)

<br><br>

## 🛠️ 작업 내용
- @BeforeEach를 사용하여 학생 목 데이터 만들기
- mypage 학생 조회 테스트 작성

<br><br>

## 🎯 리뷰 포인트
- 테스트 컨벤션에 맞게 테스트가 작성되었는가?

<br><br>

### 고민해야 할 점❓
테스트 코드를 작성하기 전 spring 테스트에 관해 학습한 내용입니다.
https://mark12345.notion.site/16b17d6854eb8085a674deee7d2dd517?pvs=4

처음에는 간단하게 메서드를 호출하여 객체를 생성하고 값을 검증을 하였습니다.
하지만 계속 실패하였고 Mock 데이터와 실제 데이터를 구분하지 않고 잘못 사용하였다는 것을 알았습니다.
필드에 @Mock은 실제 데이터를 저장하는 것이 아닌 단순히 가짜 객체를 넣어주는 것, @Autowired는 실제 데이터를 저장하고 사용하는 것입니다.

Student를 하나를 생성할 때 단순히 생성자 하나로 student를 만드는 것이 아닌 여러 함수와 DB에 저장된 초기값을 사용합니다.

```
public OnBoardingResponse onboard(OnBoardingRequest request) {
        Student student = studentService.createStudent(request);
        String accessToken = jwtUtils.createAccessToken(new TokenInfoRequest(student.getId()));
        String refreshToken = createAndSaveToken(student);
        profileImageService.saveRandomProfileImage(student);
        avatarService.createAvatar(request, student);
        studentMajorService.createStudentMajors(request.majors(), student);
        studentInterestService.createStudentInterests(request.interests(), student);
        studentLanguageService.createStudentLanguages(request.languages(), student);
        return OnBoardingResponse.from(accessToken, refreshToken);
    }
```
예를 들면 student 하나를 저장하는 이 코드에서 createStudentMajors, createStudentInterests, createStudentLanguages 값은 DB에 저장된 값을 사용하므로 테스트 코드에서 직접 넣어주기 번거로웠습니다.
따라서 
```
when(mockStudent.getName()).thenReturn("Hong gildong");
```
Mockito.when 함수를 사용하여 `mockStudent.getName()` 메서드를 호출하면 `"Hong gildong"` 이 호출하도록 하였습니다

처음에 테스트를 고려하지 않고 설계하여 각 함수마다 mock 데이터가 필요할 때, 실제 데이터가 필요할 때가 많이 달라 테스트 코드를 작성하기 까다로운 것 같습니다.

단순히 값을 저장하고, 반환하여 값을 비교하는 이외 많은 의존성을 갖고 있는 테스트의 경우 추후 학습하고 다시 작성해보겠습니다!

## 📎 커밋 범위 링크
https://github.com/buddy-ya/be/pull/46/files
<br><br>
