### PR TITLE
refactor: 온보딩과 휴대폰 인증 기능에서 논의한점 반영

### DIFF
--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -38,6 +38,7 @@ public class PhoneAuthenticationService {
         return new SendCodeResponse(phoneNumber);
     }
 
+    @Transactional(readOnly = true)
     public void verifyCode(String phoneNumber, String inputCode) {
         RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(phoneNumber)
                 .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.CODE_MISMATCH));

--- a/src/main/java/com/team/buddyya/student/domain/Avatar.java
+++ b/src/main/java/com/team/buddyya/student/domain/Avatar.java
@@ -29,7 +29,7 @@ public class Avatar extends BaseTime {
     @Column(name="loggedOut", nullable = false)
     private Boolean isLoggedOut;
 
-    @OneToOne
+    @OneToOne(fetch = LAZY)
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
 
@@ -39,5 +39,10 @@ public class Avatar extends BaseTime {
         this.student = student;
         this.isActive = true;
         this.isLoggedOut = false;
+    }
+
+    public void setStudent(Student student) {
+        this.student = student;
+        student.setAvatar(this);
     }
 }

--- a/src/main/java/com/team/buddyya/student/domain/Avatar.java
+++ b/src/main/java/com/team/buddyya/student/domain/Avatar.java
@@ -29,7 +29,7 @@ public class Avatar extends BaseTime {
     @Column(name="loggedOut", nullable = false)
     private Boolean isLoggedOut;
 
-    @OneToOne(fetch = LAZY)
+    @OneToOne
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
 

--- a/src/main/java/com/team/buddyya/student/domain/ProfileImage.java
+++ b/src/main/java/com/team/buddyya/student/domain/ProfileImage.java
@@ -35,4 +35,9 @@ public class ProfileImage extends CreatedTime {
     public void updateUrl(String newUrl) {
         this.url = newUrl;
     }
+
+    public void setStudent(Student student) {
+        this.student = student;
+        student.setProfileImage(this);
+    }
 }

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -106,4 +106,12 @@ public class Student extends BaseTime {
     public void updateName(String name) {
         this.name = name;
     }
+
+    public void setAvatar(Avatar avatar) {
+        this.avatar = avatar;
+    }
+
+    public void setProfileImage(ProfileImage profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/com/team/buddyya/student/domain/StudentInterest.java
+++ b/src/main/java/com/team/buddyya/student/domain/StudentInterest.java
@@ -34,6 +34,11 @@ public class StudentInterest extends CreatedTime {
         this.interest = interest;
     }
 
+    public void setStudent(Student student) {
+        this.student = student;
+        student.getInterests().add(this);
+    }
+
     @Override
     public String toString() {
         return interest.getInterestName();

--- a/src/main/java/com/team/buddyya/student/domain/StudentLanguage.java
+++ b/src/main/java/com/team/buddyya/student/domain/StudentLanguage.java
@@ -34,6 +34,11 @@ public class StudentLanguage extends CreatedTime {
         this.language = language;
     }
 
+    public void setStudent(Student student) {
+        this.student = student;
+        student.getLanguages().add(this);
+    }
+
     @Override
     public String toString() {
         return language.getLanguageName();

--- a/src/main/java/com/team/buddyya/student/domain/StudentMajor.java
+++ b/src/main/java/com/team/buddyya/student/domain/StudentMajor.java
@@ -33,6 +33,11 @@ public class StudentMajor {
         this.major = major;
     }
 
+    public void setStudent(Student student) {
+        this.student = student;
+        student.getMajors().add(this);
+    }
+
     @Override
     public String toString() {
         return major.getMajorName();

--- a/src/main/java/com/team/buddyya/student/repository/ProfileImageRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/ProfileImageRepository.java
@@ -9,7 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
-
-    Optional<ProfileImage> findByStudent(Student student);
 }
 

--- a/src/main/java/com/team/buddyya/student/service/FindStudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/FindStudentService.java
@@ -1,0 +1,23 @@
+package com.team.buddyya.student.service;
+
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.exception.StudentException;
+import com.team.buddyya.student.exception.StudentExceptionType;
+import com.team.buddyya.student.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FindStudentService {
+
+    private final StudentRepository studentRepository;
+
+    @Transactional(readOnly = true)
+    public Student findByStudentId(long studentId) {
+        return studentRepository.findById(studentId)
+                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/team/buddyya/student/service/MyPageService.java
+++ b/src/main/java/com/team/buddyya/student/service/MyPageService.java
@@ -20,35 +20,35 @@ public class MyPageService {
 
     private final StudentInterestService studentInterestService;
     private final StudentLanguageService studentLanguageService;
-    private final StudentService studentService;
+    private final FindStudentService findStudentService;
     private final ProfileImageService profileImageService;
 
     public MyPageUpdateResponse updateInterests(StudentInfo studentInfo, MyPageUpdateInterestsRequest request) {
-        Student student = studentService.findByStudentId(studentInfo.id());
+        Student student = findStudentService.findByStudentId(studentInfo.id());
         studentInterestService.updateStudentInterests(request.interests(), student);
         return MyPageUpdateResponse.from(UPDATE_SUCCESS_MESSAGE);
     }
 
     public MyPageUpdateResponse updateLanguages(StudentInfo studentInfo, MyPageUpdateLanguagesRequest request) {
-        Student student = studentService.findByStudentId(studentInfo.id());
+        Student student = findStudentService.findByStudentId(studentInfo.id());
         studentLanguageService.updateStudentLanguages(request.languages(), student);
         return MyPageUpdateResponse.from(UPDATE_SUCCESS_MESSAGE);
     }
 
     public MyPageUpdateResponse updateName(StudentInfo studentInfo, MyPageUpdateNameRequest request) {
-        Student student = studentService.findByStudentId(studentInfo.id());
+        Student student = findStudentService.findByStudentId(studentInfo.id());
         student.updateName(request.name());
         return MyPageUpdateResponse.from(UPDATE_SUCCESS_MESSAGE);
     }
 
     public MyPageUpdateResponse updateProfileDefaultImage(StudentInfo studentInfo, String profileImageKey) {
-        Student student = studentService.findByStudentId(studentInfo.id());
+        Student student = findStudentService.findByStudentId(studentInfo.id());
         profileImageService.updateProfileDefaultImage(student, profileImageKey);
         return MyPageUpdateResponse.from(UPDATE_SUCCESS_MESSAGE);
     }
 
     public MyPageResponse getMyPage(StudentInfo studentInfo) {
-        Student student = studentService.findByStudentId(studentInfo.id());
+        Student student = findStudentService.findByStudentId(studentInfo.id());
         return MyPageResponse.from(student);
     }
 }

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -21,6 +21,7 @@ public class StudentService {
     private final StudentRepository studentRepository;
     private final UniversityRepository universityRepository;
 
+    @Transactional(readOnly = true)
     public Student findByStudentId(long studentId) {
         return studentRepository.findById(studentId)
                 .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
@@ -41,6 +42,7 @@ public class StudentService {
         return studentRepository.save(student);
     }
 
+    @Transactional(readOnly = true)
     public boolean isDuplicateStudentNumber(String studentNumber, University university) {
         return studentRepository.findByStudentNumberAndUniversity(studentNumber, university)
                 .isPresent();
@@ -51,6 +53,7 @@ public class StudentService {
         student.updateStudentNumber(studentNumber);
     }
 
+    @Transactional(readOnly = true)
     public boolean isDuplicateStudentEmail(String email) {
         return studentRepository.findByEmail(email)
                 .isPresent();

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -21,12 +21,6 @@ public class StudentService {
     private final StudentRepository studentRepository;
     private final UniversityRepository universityRepository;
 
-    @Transactional(readOnly = true)
-    public Student findByStudentId(long studentId) {
-        return studentRepository.findById(studentId)
-                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
-    }
-
     public Student createStudent(OnBoardingRequest request) {
         University university = universityRepository.findByUniversityName(request.university())
                 .orElseThrow(() -> new StudentException(StudentExceptionType.UNIVERSITY_NOT_FOUND));


### PR DESCRIPTION
## 📌 관련 이슈
[온보딩 & 핸드폰 인증 논의한점 반영](https://github.com/buddy-ya/be/issues/47)[#47 ]

<br><br>

## 🛠️ 작업 내용

일차적으로 논의했던 점에 대한 내용 반영

-  one to one 관계에서 fetch lazy 제거
- 양방향 관계에 편의 메소드를 추가
- 순환 참조를 방지하기 위해 findByStudentId를 별도의 서비스 FindStudentService에 분리
- 순환 참조를 방지하기 위해 findByStudentId를 제외한 나머지 서비스에서 findBy 메소드들을 제거
_(제가 담당했던 부분에서는 제거해야될 메소드는 없었습니다)_
- 매개 변수에 final 키워드 확인 후 있을 시 제거
-  모든 of를 from으로 수정
-  1 : N 관계에서 findById를 findByEntity로 수정
-  조회만 하는 메서드에 readOnly = true 추가


<br><br>

## 🎯 리뷰 포인트
- 논의한점들이 잘 반영되어있는가?
- 코드 컨벤션에 위반 된 것들은 없는가?


### 고민한 점 🤔
- 처음 실행된 트랜잭션의 readonly 옵션은 변경되지 않는 것을 신경 쓰지 않고 일단 조회만 하는 메서드에는 readOnly=true를 명시해주었습니다.

- 양방향 관계를 단방향 관계로 바꾸었을때 Student와 같은 엔티티는 다른분들 코드가 영향이 많이받고,
@getter를 사용했어서 usage도 찾기가 어려워 일단 양방향 매핑 제외하고 수정하였습니다.
=> 단방향으로 수정하지 않되, 양방향 연관관계에서 연관관계의 주인에게 연관관계 편의 메소드를 작성한다

<br><br>

## 📎 커밋 범위 링크

<br><br>
