### PR TITLE
refactor: 논의한 문제 리팩토링

### DIFF
--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -32,6 +32,7 @@ public class AdminService {
     private final StudentIdCardRepository studentIdCardRepository;
     private final S3UploadService s3UploadService;
 
+    @Transactional(readOnly = true)
     public StudentIdCardListResponse getStudentIdCards() {
         List<StudentIdCardResponse> studentIdCards = studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
                 .map(StudentIdCardResponse::from)

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -7,9 +7,7 @@ import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.student.domain.Student;
-import com.team.buddyya.student.exception.StudentException;
-import com.team.buddyya.student.exception.StudentExceptionType;
-import com.team.buddyya.student.repository.StudentRepository;
+import com.team.buddyya.student.service.FindStudentService;
 import com.team.buddyya.student.service.StudentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,7 +28,7 @@ public class AdminService {
     private static final String VERIFICATION_COMPLETED_MESSAGE = "학생 인증이 완료되었습니다";
 
     private final StudentService studentService;
-    private final StudentRepository studentRepository;
+    private final FindStudentService findStudentService;
     private final StudentIdCardRepository studentIdCardRepository;
     private final S3UploadService s3UploadService;
 
@@ -42,8 +40,7 @@ public class AdminService {
     }
 
     public StudentVerificationResponse verifyStudentIdCard(StudentVerificationRequest request) {
-        Student student = studentRepository.findById(request.studentId())
-                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+        Student student = findStudentService.findByStudentId(request.studentId());
         studentIdCardRepository.deleteByStudent(student);
         s3UploadService.deleteFile(STUDENT_ID_CARD.getDirectoryName(), request.imageUrl());
         if (request.studentNumber() == null) {

--- a/src/main/java/com/team/buddyya/auth/domain/AuthToken.java
+++ b/src/main/java/com/team/buddyya/auth/domain/AuthToken.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
@@ -35,5 +34,10 @@ public class AuthToken extends CreatedTime {
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public void setAuthToken(Student student) {
+        this.student = student;
+        student.setAuthToken(this);
     }
 }

--- a/src/main/java/com/team/buddyya/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/team/buddyya/auth/service/CustomUserDetailsService.java
@@ -3,9 +3,7 @@ package com.team.buddyya.auth.service;
 import com.team.buddyya.auth.domain.CustomUserDetails;
 import com.team.buddyya.auth.domain.StudentInfo;
 import com.team.buddyya.student.domain.Student;
-import com.team.buddyya.student.exception.StudentException;
-import com.team.buddyya.student.exception.StudentExceptionType;
-import com.team.buddyya.student.repository.StudentRepository;
+import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -17,12 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final StudentRepository studentRepository;
+    private final FindStudentService findStudentService;
 
     @Override
     public CustomUserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-        Student student = studentRepository.findById(Long.parseLong(id))
-                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+        Student student = findStudentService.findByStudentId(Long.parseLong(id));
         StudentInfo studentInfo = StudentInfo.from(student);
         return new CustomUserDetails(studentInfo);
     }

--- a/src/main/java/com/team/buddyya/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/team/buddyya/auth/service/CustomUserDetailsService.java
@@ -17,7 +17,9 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     private final FindStudentService findStudentService;
 
+
     @Override
+    @Transactional(readOnly = true)
     public CustomUserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
         Student student = findStudentService.findByStudentId(Long.parseLong(id));
         StudentInfo studentInfo = StudentInfo.from(student);

--- a/src/main/java/com/team/buddyya/certification/domain/StudentIdCard.java
+++ b/src/main/java/com/team/buddyya/certification/domain/StudentIdCard.java
@@ -36,4 +36,9 @@ public class StudentIdCard extends CreatedTime {
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+
+    public void setStudent(Student student) {
+        this.student = student;
+        student.setStudentIdCard(this);
+    }
 }

--- a/src/main/java/com/team/buddyya/certification/service/CertificationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/CertificationService.java
@@ -107,6 +107,7 @@ public class CertificationService {
         return CertificationResponse.from(true);
     }
 
+    @Transactional(readOnly = true)
     public CertificationStatusResponse isCertificated(StudentInfo studentInfo) {
         Student student = findStudentService.findByStudentId(studentInfo.id());
         boolean isStudentIdCardRequested = studentIdCardRepository.findByStudent(student)
@@ -114,6 +115,7 @@ public class CertificationService {
         return CertificationStatusResponse.from(student, isStudentIdCardRequested);
     }
 
+    @Transactional(readOnly = true)
     public StudentIdCardResponse getStudentIdCard(StudentInfo studentInfo) {
         StudentIdCard studentIdCard = studentIdCardRepository.findByStudent_Id(studentInfo.id())
                 .orElseThrow(() -> new CertificateException(CertificateExceptionType.STUDENT_ID_CARD_NOT_FOUND));

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -114,4 +114,12 @@ public class Student extends BaseTime {
     public void setProfileImage(ProfileImage profileImage) {
         this.profileImage = profileImage;
     }
+
+    public void setAuthToken(AuthToken authToken) {
+        this.authToken = authToken;
+    }
+
+    public void setStudentIdCard(StudentIdCard studentIdCard) {
+        this.studentIdCard = studentIdCard;
+    }
 }

--- a/src/main/java/com/team/buddyya/student/service/MyPageService.java
+++ b/src/main/java/com/team/buddyya/student/service/MyPageService.java
@@ -47,6 +47,7 @@ public class MyPageService {
         return MyPageUpdateResponse.from(UPDATE_SUCCESS_MESSAGE);
     }
 
+    @Transactional(readOnly = true)
     public MyPageResponse getMyPage(StudentInfo studentInfo) {
         Student student = findStudentService.findByStudentId(studentInfo.id());
         return MyPageResponse.from(student);


### PR DESCRIPTION
## 📌 관련 이슈
[논의한 문제 리팩토링[#50 ]](https://github.com/buddy-ya/be/issues/50)
<br><br>

## 🛠️ 작업 내용
- 양방향 관계에 편의 메소드를 추가
- student 조회 서비스를 분리한 findStudentService 참조하도록 수정
- 조회 메서드에 읽기 전용 트랜잭션인 @Transactional(readOnly = true) 추가
<br><br>

## 🎯 리뷰 포인트
- 논의한점들이 잘 반영되어있는가?
- 코드 컨벤션이 지켜졌는가?
<br><br>

## 고민한 점 🤔
읽기 전용 트랜잭션을 적용할 때 외부 api를 참조하는 경우는 어떻게 해야할까?
```
@Transactional(readOnly = true)
    public CertificationResponse certificateEmail(StudentInfo studentInfo, EmailCertificationRequest emailRequest) {
        Student student = findStudentService.findByStudentId(studentInfo.id());
        validateStatusAndEmail(emailRequest, student);
        try {
            Map<String, Object> univCertResponse = UnivCert.certify(univcertApiKey, emailRequest.email(), emailRequest.univName(), true);
            boolean isSuccess = (Boolean) univCertResponse.get("success");
            return CertificationResponse.from(isSuccess);
        } catch (IOException e) {
            throw new CertificateException(CertificateExceptionType.CERTIFICATE_FAILED);
        }
    }
```
예를 들면 다음과 같은 코드처럼
` UnivCert.certify(univcertApiKey, emailRequest.email(), emailRequest.univName(), true); `
외부 api를 호출하는 경우 외부에서 변경이 일어날 수도 있지 않나? 이 때는 `readOnly = true`를 적용해야 할까? 
외부 API와 JPA는 독립적으로 작용한다는 것을 간과하였고 결론적으로
나의 service 코드에 조회 메서드만 있다면 `readOnly = true`를 적용하였습니다

## 📎 커밋 범위 링크
[커밋 범위 링크](https://github.com/buddy-ya/be/pull/51/files)
<br><br>
