### PR TITLE
refactor: 논의한 문제에 대해서 리팩토링

### DIFF
--- a/src/main/java/com/team/buddyya/chatting/domain/Chat.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/Chat.java
@@ -2,13 +2,18 @@ package com.team.buddyya.chatting.domain;
 
 import com.team.buddyya.common.domain.CreatedTime;
 import com.team.buddyya.student.domain.Student;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/team/buddyya/chatting/domain/Chatroom.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/Chatroom.java
@@ -1,11 +1,16 @@
 package com.team.buddyya.chatting.domain;
 
 import com.team.buddyya.common.domain.CreatedTime;
-import jakarta.persistence.*;
-import lombok.Getter;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
 
 @Entity
 @Getter

--- a/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
@@ -1,7 +1,14 @@
 package com.team.buddyya.chatting.domain;
 
 import com.team.buddyya.student.domain.Student;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,11 +29,11 @@ public class ChatroomStudent {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatroom_id")
-    private Chatroom chatRoom;
+    private Chatroom chatroom;
 
     @Builder
     public ChatroomStudent(Student student, Chatroom chatroom) {
         this.student = student;
-        this.chatRoom = chatroom;
+        this.chatroom = chatroom;
     }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/Bookmark.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Bookmark.java
@@ -39,4 +39,9 @@ public class Bookmark extends CreatedTime {
         this.feed = feed;
         this.student = student;
     }
+
+    public void setFeed(Feed feed) {
+        this.feed = feed;
+        feed.getBookmarks().add(this);
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/Comment.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Comment.java
@@ -47,6 +47,11 @@ public class Comment extends BaseTime {
         this.content = content;
     }
 
+    public void setFeed(Feed feed) {
+        this.feed = feed;
+        feed.getComments().add(this);
+    }
+
     public void updateComment(String content) {
         this.content = content;
     }

--- a/src/main/java/com/team/buddyya/feed/domain/CommentInfo.java
+++ b/src/main/java/com/team/buddyya/feed/domain/CommentInfo.java
@@ -6,7 +6,7 @@ public record CommentInfo(
         boolean isCommentOwner
 ) {
 
-    public static CommentInfo of(Comment comment, Long feedOwnerId, Long currentUserId) {
+    public static CommentInfo from(Comment comment, Long feedOwnerId, Long currentUserId) {
         return new CommentInfo(
                 comment,
                 feedOwnerId.equals(comment.getStudent().getId()),

--- a/src/main/java/com/team/buddyya/feed/domain/FeedImage.java
+++ b/src/main/java/com/team/buddyya/feed/domain/FeedImage.java
@@ -38,4 +38,9 @@ public class FeedImage extends CreatedTime {
         this.feed = feed;
         this.url = url;
     }
+
+    public void setFeed(Feed feed) {
+        this.feed = feed;
+        feed.getImages().add(this);
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/FeedUserAction.java
+++ b/src/main/java/com/team/buddyya/feed/domain/FeedUserAction.java
@@ -6,7 +6,7 @@ public record FeedUserAction(
         boolean isBookmarked
 ) {
 
-    public static FeedUserAction of(boolean isFeedOwner, boolean isLiked, boolean isBookmarked) {
+    public static FeedUserAction from(boolean isFeedOwner, boolean isLiked, boolean isBookmarked) {
         return new FeedUserAction(isFeedOwner, isLiked, isBookmarked);
     }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/Like.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Like.java
@@ -42,6 +42,11 @@ public class Like extends CreatedTime {
         this.student = student;
     }
 
+    public void setFeed(Feed feed) {
+        this.feed = feed;
+        feed.getLikes().add(this);
+    }
+
     @PrePersist
     private void prePersist() {
         feed.increaseLikeCount();

--- a/src/main/java/com/team/buddyya/feed/respository/BookmarkRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/BookmarkRepository.java
@@ -1,20 +1,20 @@
 package com.team.buddyya.feed.respository;
 
 import com.team.buddyya.feed.domain.Bookmark;
+import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.student.domain.Student;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
-    Optional<Bookmark> findByStudentIdAndFeedId(Long studentId, Long feedId);
+    Optional<Bookmark> findByStudentAndFeed(Student student, Feed feed);
 
-    boolean existsByStudentIdAndFeedId(Long studentId, Long feedId);
+    boolean existsByStudentAndFeed(Student student, Feed feed);
 
     Page<Bookmark> findAllByStudent(Student student, Pageable pageable);
 }

--- a/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/FeedRepository.java
@@ -2,6 +2,7 @@ package com.team.buddyya.feed.respository;
 
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.student.domain.Student;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,7 +15,11 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     Page<Feed> findAllByStudent(Student student, Pageable pageable);
 
+    List<Feed> findAllByStudent(Student student);
+
     Page<Feed> findByTitleContainingOrContentContaining(String titleQuery, String contentQuery, Pageable pageable);
 
     Page<Feed> findByLikeCountGreaterThanEqual(int likeCount, Pageable pageable);
+
+    void deleteAllByStudent(Student student);
 }

--- a/src/main/java/com/team/buddyya/feed/respository/LikeRepository.java
+++ b/src/main/java/com/team/buddyya/feed/respository/LikeRepository.java
@@ -1,14 +1,16 @@
 package com.team.buddyya.feed.respository;
 
+import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.domain.Like;
+import com.team.buddyya.student.domain.Student;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    
+    Optional<Like> findByStudentAndFeed(Student student, Feed feed);
 
-    Optional<Like> findByStudentIdAndFeedId(Long studentId, Long feedId);
-
-    boolean existsByStudentIdAndFeedId(Long studentId, Long feedId);
+    boolean existsByStudentAndFeed(Student student, Feed feed);
 }

--- a/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
+++ b/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
@@ -12,9 +12,9 @@ import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.StudentRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -25,11 +25,13 @@ public class BookmarkService {
     private final StudentRepository studentRepository;
     private final FeedRepository feedRepository;
 
-    public boolean existsByStudentAndFeed(Student student, Feed feed) {
+    @Transactional(readOnly = true)
+    boolean existsByStudentAndFeed(Student student, Feed feed) {
         return bookmarkRepository.existsByStudentAndFeed(student, feed);
     }
 
-    private Bookmark findByStudentAndFeed(Student student, Feed feed) {
+    @Transactional(readOnly = true)
+    Bookmark findByStudentAndFeed(Student student, Feed feed) {
         return bookmarkRepository.findByStudentAndFeed(student, feed)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_BOOKMARKED));
     }

--- a/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
+++ b/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
@@ -7,6 +7,7 @@ import com.team.buddyya.feed.dto.response.BookmarkResponse;
 import com.team.buddyya.feed.exception.FeedException;
 import com.team.buddyya.feed.exception.FeedExceptionType;
 import com.team.buddyya.feed.respository.BookmarkRepository;
+import com.team.buddyya.feed.respository.FeedRepository;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
@@ -22,7 +23,7 @@ public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
     private final StudentRepository studentRepository;
-    private final FeedService feedService;
+    private final FeedRepository feedRepository;
 
     public boolean existsByStudentIdAndFeedId(Long studentId, Long feedId) {
         return bookmarkRepository.existsByStudentIdAndFeedId(studentId, feedId);
@@ -34,7 +35,8 @@ public class BookmarkService {
     }
 
     public BookmarkResponse toggleBookmark(StudentInfo studentInfo, Long feedId) {
-        Feed feed = feedService.findFeedByFeedId(feedId);
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
         boolean isBookmarked = existsByStudentIdAndFeedId(studentInfo.id(), feedId);
         if (isBookmarked) {
             Bookmark bookmark = findByStudentIdAndFeedId(studentInfo.id(), feedId);

--- a/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
+++ b/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
@@ -25,26 +25,26 @@ public class BookmarkService {
     private final StudentRepository studentRepository;
     private final FeedRepository feedRepository;
 
-    public boolean existsByStudentIdAndFeedId(Long studentId, Long feedId) {
-        return bookmarkRepository.existsByStudentIdAndFeedId(studentId, feedId);
+    public boolean existsByStudentAndFeed(Student student, Feed feed) {
+        return bookmarkRepository.existsByStudentAndFeed(student, feed);
     }
 
-    private Bookmark findByStudentIdAndFeedId(Long studentId, Long feedId) {
-        return bookmarkRepository.findByStudentIdAndFeedId(studentId, feedId)
+    private Bookmark findByStudentAndFeed(Student student, Feed feed) {
+        return bookmarkRepository.findByStudentAndFeed(student, feed)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_BOOKMARKED));
     }
 
     public BookmarkResponse toggleBookmark(StudentInfo studentInfo, Long feedId) {
         Feed feed = feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
-        boolean isBookmarked = existsByStudentIdAndFeedId(studentInfo.id(), feedId);
+        Student student = studentRepository.findById(studentInfo.id())
+                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+        boolean isBookmarked = existsByStudentAndFeed(student, feed);
         if (isBookmarked) {
-            Bookmark bookmark = findByStudentIdAndFeedId(studentInfo.id(), feedId);
+            Bookmark bookmark = findByStudentAndFeed(student, feed);
             bookmarkRepository.delete(bookmark);
             return BookmarkResponse.from(false);
         }
-        Student student = studentRepository.findById(studentInfo.id())
-                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
         Bookmark bookmark = Bookmark.builder()
                 .feed(feed)
                 .student(student)

--- a/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
+++ b/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
@@ -9,9 +9,7 @@ import com.team.buddyya.feed.exception.FeedExceptionType;
 import com.team.buddyya.feed.respository.BookmarkRepository;
 import com.team.buddyya.feed.respository.FeedRepository;
 import com.team.buddyya.student.domain.Student;
-import com.team.buddyya.student.exception.StudentException;
-import com.team.buddyya.student.exception.StudentExceptionType;
-import com.team.buddyya.student.repository.StudentRepository;
+import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
-    private final StudentRepository studentRepository;
+    private final FindStudentService findStudentService;
     private final FeedRepository feedRepository;
 
     @Transactional(readOnly = true)
@@ -39,8 +37,7 @@ public class BookmarkService {
     public BookmarkResponse toggleBookmark(StudentInfo studentInfo, Long feedId) {
         Feed feed = feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
-        Student student = studentRepository.findById(studentInfo.id())
-                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+        Student student = findStudentService.findByStudentId(studentInfo.id());
         boolean isBookmarked = existsByStudentAndFeed(student, feed);
         if (isBookmarked) {
             Bookmark bookmark = findByStudentAndFeed(student, feed);

--- a/src/main/java/com/team/buddyya/feed/service/CategoryService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CategoryService.java
@@ -4,18 +4,19 @@ import com.team.buddyya.feed.domain.Category;
 import com.team.buddyya.feed.exception.FeedException;
 import com.team.buddyya.feed.exception.FeedExceptionType;
 import com.team.buddyya.feed.respository.CategoryRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class CategoryService {
-    
+
     private final CategoryRepository categoryRepository;
 
-    public Category getCategory(String categoryName) {
+    @Transactional(readOnly = true)
+    Category getCategory(String categoryName) {
         return categoryRepository.findByName(categoryName)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.CATEGORY_NOT_FOUND));
     }

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -14,9 +14,7 @@ import com.team.buddyya.feed.exception.FeedExceptionType;
 import com.team.buddyya.feed.respository.CommentRepository;
 import com.team.buddyya.feed.respository.FeedRepository;
 import com.team.buddyya.student.domain.Student;
-import com.team.buddyya.student.exception.StudentException;
-import com.team.buddyya.student.exception.StudentExceptionType;
-import com.team.buddyya.student.repository.StudentRepository;
+import com.team.buddyya.student.service.FindStudentService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,7 +27,7 @@ public class CommentService {
 
     private final FeedRepository feedRepository;
     private final CommentRepository commentRepository;
-    private final StudentRepository studentRepository;
+    private final FindStudentService findStudentService;
 
     @Transactional(readOnly = true)
     Feed findFeedByFeedId(Long feedId) {
@@ -54,8 +52,7 @@ public class CommentService {
     }
 
     public CommentCreateResponse createComment(StudentInfo studentInfo, Long feedId, CommentCreateRequest request) {
-        Student student = studentRepository.findById(studentInfo.id())
-                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+        Student student = findStudentService.findByStudentId(studentInfo.id());
         Feed feed = findFeedByFeedId(feedId);
         Comment comment = Comment.builder()
                 .student(student)

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -46,7 +46,7 @@ public class CommentService {
     public List<CommentResponse> getComments(StudentInfo studentInfo, Long feedId) {
         Feed feed = findFeedByFeedId(feedId);
         List<CommentInfo> commentInfos = feed.getComments().stream()
-                .map(comment -> CommentInfo.of(comment, feed.getStudent().getId(), studentInfo.id()))
+                .map(comment -> CommentInfo.from(comment, feed.getStudent().getId(), studentInfo.id()))
                 .toList();
         return commentInfos.stream()
                 .map(CommentResponse::from)
@@ -63,7 +63,7 @@ public class CommentService {
                 .content(request.content())
                 .build();
         commentRepository.save(comment);
-        CommentInfo commentInfo = CommentInfo.of(comment, feed.getStudent().getId(), studentInfo.id());
+        CommentInfo commentInfo = CommentInfo.from(comment, feed.getStudent().getId(), studentInfo.id());
         return CommentCreateResponse.from(commentInfo);
     }
 
@@ -73,7 +73,7 @@ public class CommentService {
         Comment comment = findCommentByCommentId(commentId);
         validateCommentOwner(studentInfo.id(), comment);
         comment.updateComment(request.content());
-        CommentInfo commentInfo = CommentInfo.of(comment, feed.getStudent().getId(), studentInfo.id());
+        CommentInfo commentInfo = CommentInfo.from(comment, feed.getStudent().getId(), studentInfo.id());
         return CommentUpdateResponse.from(commentInfo);
     }
 

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -17,10 +17,10 @@ import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.StudentRepository;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -31,15 +31,18 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final StudentRepository studentRepository;
 
-    private Feed findFeedByFeedId(Long feedId) {
+    @Transactional(readOnly = true)
+    Feed findFeedByFeedId(Long feedId) {
         return feedRepository.findById(feedId).orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }
 
-    private Comment findCommentByCommentId(Long commentId) {
+    @Transactional(readOnly = true)
+    Comment findCommentByCommentId(Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.COMMENT_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public List<CommentResponse> getComments(StudentInfo studentInfo, Long feedId) {
         Feed feed = findFeedByFeedId(feedId);
         List<CommentInfo> commentInfos = feed.getComments().stream()

--- a/src/main/java/com/team/buddyya/feed/service/FeedImageService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedImageService.java
@@ -17,14 +17,15 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 @RequiredArgsConstructor
 public class FeedImageService {
+
     private final S3UploadService s3UploadService;
     private final FeedImageRepository feedImageRepository;
 
-    public void uploadFeedImages(List<FeedImage> images){
+    public void uploadFeedImages(List<FeedImage> images) {
         feedImageRepository.saveAll(images);
     }
 
-    public void deleteFeedImages(Feed feed){
+    public void deleteFeedImages(Feed feed) {
         feedImageRepository.deleteByFeed(feed);
     }
 

--- a/src/main/java/com/team/buddyya/feed/service/FeedImageService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedImageService.java
@@ -7,10 +7,10 @@ import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.domain.FeedImage;
 import com.team.buddyya.feed.respository.FeedImageRepository;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -52,13 +52,13 @@ public class FeedService {
     public FeedListResponse getFeeds(StudentInfo studentInfo, Pageable pageable, FeedListRequest request) {
         String keyword = request.keyword();
         if (keyword == null || keyword.isBlank()) {
-            Page<Feed> feeds = fetchFeedsByCategory(request, pageable);
+            Page<Feed> feeds = getFeedsByCategory(request, pageable);
             List<FeedResponse> response = feeds.getContent().stream()
                     .map(feed -> createFeedResponse(feed, studentInfo.id()))
                     .toList();
             return FeedListResponse.from(response, feeds);
         }
-        Page<Feed> feeds = fetchFeedsByKeyword(keyword, pageable);
+        Page<Feed> feeds = getFeedsByKeyword(keyword, pageable);
         List<FeedResponse> response = feeds.getContent().stream()
                 .map(feed -> createFeedResponse(feed, studentInfo.id()))
                 .toList();
@@ -108,7 +108,7 @@ public class FeedService {
         feedRepository.delete(feed);
     }
 
-    private Page<Feed> fetchFeedsByCategory(FeedListRequest request, Pageable pageable) {
+    private Page<Feed> getFeedsByCategory(FeedListRequest request, Pageable pageable) {
         Category category = categoryService.getCategory(request.category());
         Pageable customPageable = PageRequest.of(
                 pageable.getPageNumber(),
@@ -118,7 +118,7 @@ public class FeedService {
         return feedRepository.findAllByCategoryName(category.getName(), customPageable);
     }
 
-    private Page<Feed> fetchFeedsByKeyword(String keyword, Pageable pageable) {
+    private Page<Feed> getFeedsByKeyword(String keyword, Pageable pageable) {
         return feedRepository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
     }
 

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -131,7 +131,7 @@ public class FeedService {
         boolean isFeedOwner = student.getId().equals(feed.getStudent().getId());
         boolean isLiked = likeRepository.existsByStudentAndFeed(student, feed);
         boolean isBookmarked = bookmarkRepository.existsByStudentAndFeed(student, feed);
-        return FeedUserAction.of(isFeedOwner, isLiked, isBookmarked);
+        return FeedUserAction.from(isFeedOwner, isLiked, isBookmarked);
     }
 
     public void createFeed(StudentInfo studentInfo, FeedCreateRequest request) {

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -1,7 +1,11 @@
 package com.team.buddyya.feed.service;
 
 import com.team.buddyya.auth.domain.StudentInfo;
-import com.team.buddyya.feed.domain.*;
+import com.team.buddyya.feed.domain.Bookmark;
+import com.team.buddyya.feed.domain.Category;
+import com.team.buddyya.feed.domain.Feed;
+import com.team.buddyya.feed.domain.FeedImage;
+import com.team.buddyya.feed.domain.FeedUserAction;
 import com.team.buddyya.feed.dto.request.feed.FeedCreateRequest;
 import com.team.buddyya.feed.dto.request.feed.FeedListRequest;
 import com.team.buddyya.feed.dto.request.feed.FeedUpdateRequest;
@@ -17,6 +21,7 @@ import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.StudentRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -24,8 +29,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Service
 @Transactional
@@ -41,7 +44,7 @@ public class FeedService {
     private final BookmarkRepository bookmarkRepository;
     private final FeedImageService feedImageService;
 
-    public Feed findFeedByFeedId(Long feedId) {
+    private Feed findFeedByFeedId(Long feedId) {
         return feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }

--- a/src/main/java/com/team/buddyya/feed/service/LikeService.java
+++ b/src/main/java/com/team/buddyya/feed/service/LikeService.java
@@ -6,6 +6,7 @@ import com.team.buddyya.feed.domain.Like;
 import com.team.buddyya.feed.dto.response.LikeResponse;
 import com.team.buddyya.feed.exception.FeedException;
 import com.team.buddyya.feed.exception.FeedExceptionType;
+import com.team.buddyya.feed.respository.FeedRepository;
 import com.team.buddyya.feed.respository.LikeRepository;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.exception.StudentException;
@@ -22,7 +23,7 @@ public class LikeService {
 
     private final LikeRepository likeRepository;
     private final StudentRepository studentRepository;
-    private final FeedService feedService;
+    private final FeedRepository feedRepository;
 
     public boolean existsByStudentIdAndFeedId(Long studentId, Long feedId) {
         return likeRepository.existsByStudentIdAndFeedId(studentId, feedId);
@@ -34,7 +35,8 @@ public class LikeService {
     }
 
     public LikeResponse toggleLike(StudentInfo studentInfo, Long feedId) {
-        Feed feed = feedService.findFeedByFeedId(feedId);
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
         boolean isLiked = existsByStudentIdAndFeedId(studentInfo.id(), feedId);
         if (isLiked) {
             Like like = findLikeByStudentIdAndFeedId(studentInfo.id(), feedId);

--- a/src/main/java/com/team/buddyya/feed/service/LikeService.java
+++ b/src/main/java/com/team/buddyya/feed/service/LikeService.java
@@ -25,26 +25,27 @@ public class LikeService {
     private final StudentRepository studentRepository;
     private final FeedRepository feedRepository;
 
-    public boolean existsByStudentIdAndFeedId(Long studentId, Long feedId) {
-        return likeRepository.existsByStudentIdAndFeedId(studentId, feedId);
+    private boolean existsByStudentAndFeed(Student student, Feed feed) {
+        return likeRepository.existsByStudentAndFeed(student, feed);
     }
 
-    public Like findLikeByStudentIdAndFeedId(Long studentId, Long feedId) {
-        return likeRepository.findByStudentIdAndFeedId(studentId, feedId)
+    private Like findLikeByStudentAndFeed(Student student, Feed feed) {
+        return likeRepository.findByStudentAndFeed(student, feed)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_LIKED));
     }
 
     public LikeResponse toggleLike(StudentInfo studentInfo, Long feedId) {
         Feed feed = feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
-        boolean isLiked = existsByStudentIdAndFeedId(studentInfo.id(), feedId);
+
+        Student student = studentRepository.findById(studentInfo.id())
+                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+        boolean isLiked = existsByStudentAndFeed(student, feed);
         if (isLiked) {
-            Like like = findLikeByStudentIdAndFeedId(studentInfo.id(), feedId);
+            Like like = findLikeByStudentAndFeed(student, feed);
             likeRepository.delete(like);
             return LikeResponse.from(false, feed.getLikeCount());
         }
-        Student student = studentRepository.findById(studentInfo.id())
-                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
         Like like = Like.builder()
                 .feed(feed)
                 .student(student)

--- a/src/main/java/com/team/buddyya/feed/service/LikeService.java
+++ b/src/main/java/com/team/buddyya/feed/service/LikeService.java
@@ -9,9 +9,7 @@ import com.team.buddyya.feed.exception.FeedExceptionType;
 import com.team.buddyya.feed.respository.FeedRepository;
 import com.team.buddyya.feed.respository.LikeRepository;
 import com.team.buddyya.student.domain.Student;
-import com.team.buddyya.student.exception.StudentException;
-import com.team.buddyya.student.exception.StudentExceptionType;
-import com.team.buddyya.student.repository.StudentRepository;
+import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeService {
 
     private final LikeRepository likeRepository;
-    private final StudentRepository studentRepository;
+    private final FindStudentService findStudentService;
     private final FeedRepository feedRepository;
 
     @Transactional(readOnly = true)
@@ -39,8 +37,7 @@ public class LikeService {
     public LikeResponse toggleLike(StudentInfo studentInfo, Long feedId) {
         Feed feed = feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
-        Student student = studentRepository.findById(studentInfo.id())
-                .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
+        Student student = findStudentService.findByStudentId(studentInfo.id());
         boolean isLiked = existsByStudentAndFeed(student, feed);
         if (isLiked) {
             Like like = findLikeByStudentAndFeed(student, feed);

--- a/src/main/java/com/team/buddyya/feed/service/LikeService.java
+++ b/src/main/java/com/team/buddyya/feed/service/LikeService.java
@@ -12,9 +12,9 @@ import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.StudentRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -25,11 +25,13 @@ public class LikeService {
     private final StudentRepository studentRepository;
     private final FeedRepository feedRepository;
 
-    private boolean existsByStudentAndFeed(Student student, Feed feed) {
+    @Transactional(readOnly = true)
+    boolean existsByStudentAndFeed(Student student, Feed feed) {
         return likeRepository.existsByStudentAndFeed(student, feed);
     }
 
-    private Like findLikeByStudentAndFeed(Student student, Feed feed) {
+    @Transactional(readOnly = true)
+    Like findLikeByStudentAndFeed(Student student, Feed feed) {
         return likeRepository.findByStudentAndFeed(student, feed)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_LIKED));
     }
@@ -37,7 +39,6 @@ public class LikeService {
     public LikeResponse toggleLike(StudentInfo studentInfo, Long feedId) {
         Feed feed = feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
-
         Student student = studentRepository.findById(studentInfo.id())
                 .orElseThrow(() -> new StudentException(StudentExceptionType.STUDENT_NOT_FOUND));
         boolean isLiked = existsByStudentAndFeed(student, feed);

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -1,18 +1,28 @@
 package com.team.buddyya.student.domain;
 
-import com.team.buddyya.auth.domain.AuthToken;
-import com.team.buddyya.certification.domain.StudentIdCard;
-import com.team.buddyya.common.domain.BaseTime;
-import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.util.List;
-
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
+
+import com.team.buddyya.auth.domain.AuthToken;
+import com.team.buddyya.certification.domain.StudentIdCard;
+import com.team.buddyya.common.domain.BaseTime;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "student")
@@ -79,7 +89,8 @@ public class Student extends BaseTime {
     private StudentIdCard studentIdCard;
 
     @Builder
-    public Student(String name, String phoneNumber, String country, Boolean isKorean, Role role, University university, Gender gender) {
+    public Student(String name, String phoneNumber, String country, Boolean isKorean, Role role, University university,
+                   Gender gender) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.country = country;
@@ -101,6 +112,10 @@ public class Student extends BaseTime {
 
     public void updateEmail(String email) {
         this.email = email;
+    }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
     }
 
     public void updateName(String name) {

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -1,6 +1,8 @@
 package com.team.buddyya.student.service;
 
 import com.team.buddyya.auth.domain.StudentInfo;
+import com.team.buddyya.feed.respository.FeedRepository;
+import com.team.buddyya.feed.respository.LikeRepository;
 import com.team.buddyya.student.domain.Gender;
 import com.team.buddyya.student.domain.Role;
 import com.team.buddyya.student.domain.Student;
@@ -10,6 +12,7 @@ import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.StudentRepository;
 import com.team.buddyya.student.repository.UniversityRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +24,9 @@ public class StudentService {
 
     private final StudentRepository studentRepository;
     private final UniversityRepository universityRepository;
+    private final FeedRepository feedRepository;
+    private final FindStudentService findStudentService;
+    private final LikeRepository likeRepository;
 
     public Student createStudent(OnBoardingRequest request) {
         University university = universityRepository.findByUniversityName(request.university())
@@ -55,6 +61,8 @@ public class StudentService {
     }
 
     public void deleteStudent(StudentInfo studentInfo) {
-        studentRepository.deleteById(studentInfo.id());
+        Student student = findStudentService.findByStudentId(studentInfo.id());
+        String randomPhoneNumber = "deleted_" + UUID.randomUUID().toString().substring(0, 3);
+        student.updatePhoneNumber(randomPhoneNumber);
     }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -2,7 +2,7 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/buddy_ya
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
-spring.datasource.password=1234
+spring.datasource.password=1942
 # JPA settings
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 📌 관련 이슈
[논의한 문제에 대해서 리팩토링 #60](https://github.com/buddy-ya/be/issues/60)
<br><br>

## 🛠️ 작업 내용
- 양방향 편의 메서드 작성
- 순환 참조를 피하기 위해 DB 조회시 서비스가 아닌 DAO 참조
- 컨벤션을 위해 정적 팩토리 메서드에 of 대신 from 사용
- 다대일 관계에서 조회시 findByEntity로 수정
- 서비스 계층 조회 메서드에 readOnly = true로 명시
- 테스터를 위한 `회원탈퇴 api` 삭제 api 대신 전화번호 필드에 난수 설정
<br><br>

## 🎯 고민했던 점 

> 정말 양방향이어야 할까요?

연관관계의 매핑을 맺을 때 가장 중요하게 생각하는 점은 `생명 주기가 동일한가?` 라고 생각해요.
`Feed`의 경우 `Like`, `Bookmark`, `Comment`, `FeedImage` 엔티티와 생명 주기가 동일할까요?
적어도 `Feed`가 삭제되었을 때 `feed_id`를 참조했던 엔티티는 모두 삭제되어야겠지만,
`Like`가 삭제되었다고 해서 `Feed`가 삭제될 필요는 없죠. (완전히 동일하지 않고, 부모가 자식을 관리하면 됩니다.)

논의한 점에 따라 양방향으로 설계했지만, 실제 자식 서비스 계층에서 `Feed`를 많이 호출하지 않는다는 점에서,
단방향으로 바꿔보려는 시도를 추후에 해보고자 합니다 :)

> 피드 관련 활동시 회원 탈퇴가 정상적으로 이뤄지지 않음

테스터를 위한 기존에 회원 탈퇴 api는 `studentRepository`에서 `student`를 삭제하는 방법이였는데요,
`Feed` 및 하위의 `Like`등이 `student`를 외래키로 참조하고 있어, 피드 관련 활동 시에 회원 탈퇴가 정상적으로 이뤄지지 않았습니다.
`Feed`를 삭제하면, 양방향을 맺었으니 `orphanRemoval`로 자식들도 자연스럽게 삭제될까요?
본인의 `Feed`를 삭제하는 것이 본인과 관계된 모든 `Like`를 삭제하는 것이 아니니, 삭제되지 않습니다.
따라서 삭제를 위해서는 `student`를 외래키로 참조하는 엔티티들을 하나하나 삭제해줘야 하는데요.
다른 좋은 방법이 있는지 찾아봐야 할 것 같습니다.

일단 테스터를 위한 간단한 api이니, 탈퇴시 휴대번호에 난수를 넣어 기존 번호로 재가입이 가능하게 설정했습니다.
<br><br>

## 📎 커밋 범위 링크

<br><br>
