### PR TITLE
refactor: 대학교 이메일 인증 구글 smtp를 사용하여 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-	// 대학 메일 인증 univcert
-	implementation 'com.github.in-seo:univcert:master-SNAPSHOT'
+	// 대학 메일 인증 smtp
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	// 문자 인증 nurigo
 	implementation 'net.nurigo:sdk:4.2.7'
 

--- a/src/main/java/com/team/buddyya/certification/controller/CertificationController.java
+++ b/src/main/java/com/team/buddyya/certification/controller/CertificationController.java
@@ -29,8 +29,10 @@ public class CertificationController {
     @PostMapping("/email/send")
     public ResponseEntity<CertificationResponse> sendEmail(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                            @RequestBody EmailCertificationRequest emailCertificationRequest) {
-        return ResponseEntity.ok(
-                certificationService.certificateEmail(userDetails.getStudentInfo(), emailCertificationRequest));
+
+        String generatedCode = certificationService.sendEmail(userDetails.getStudentInfo(), emailCertificationRequest);
+        CertificationResponse response = certificationService.saveCode(emailCertificationRequest.email(), generatedCode);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/email/verify-code")

--- a/src/main/java/com/team/buddyya/certification/controller/CertificationController.java
+++ b/src/main/java/com/team/buddyya/certification/controller/CertificationController.java
@@ -8,6 +8,7 @@ import com.team.buddyya.certification.dto.response.CertificationResponse;
 import com.team.buddyya.certification.dto.response.CertificationStatusResponse;
 import com.team.buddyya.certification.dto.response.StudentIdCardResponse;
 import com.team.buddyya.certification.service.CertificationService;
+import com.team.buddyya.certification.service.EmailSendService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,12 +26,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class CertificationController {
 
     private final CertificationService certificationService;
+    private final EmailSendService emailSendService;
 
     @PostMapping("/email/send")
     public ResponseEntity<CertificationResponse> sendEmail(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                            @RequestBody EmailCertificationRequest emailCertificationRequest) {
 
-        String generatedCode = certificationService.sendEmail(userDetails.getStudentInfo(), emailCertificationRequest);
+        String generatedCode = emailSendService.sendEmail(userDetails.getStudentInfo(), emailCertificationRequest);
         CertificationResponse response = certificationService.saveCode(emailCertificationRequest.email(), generatedCode);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/team/buddyya/certification/domain/StudentEmail.java
+++ b/src/main/java/com/team/buddyya/certification/domain/StudentEmail.java
@@ -1,0 +1,35 @@
+package com.team.buddyya.certification.domain;
+
+import com.team.buddyya.common.domain.CreatedTime;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Table(name = "student_email")
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class StudentEmail extends CreatedTime {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 4, nullable = false, unique = true)
+    private String authenticationCode;
+
+    public StudentEmail(String email, String authenticationCode) {
+        this.email = email;
+        this.authenticationCode = authenticationCode;
+    }
+
+    public void updateAuthenticationCode(String authenticationCode) {
+        this.authenticationCode = authenticationCode;
+    }
+}

--- a/src/main/java/com/team/buddyya/certification/dto/request/EmailCertificationRequest.java
+++ b/src/main/java/com/team/buddyya/certification/dto/request/EmailCertificationRequest.java
@@ -1,7 +1,6 @@
 package com.team.buddyya.certification.dto.request;
 
 public record EmailCertificationRequest(
-        String email,
-        String univName
+        String email
 ) {
 }

--- a/src/main/java/com/team/buddyya/certification/dto/request/EmailCodeRequest.java
+++ b/src/main/java/com/team/buddyya/certification/dto/request/EmailCodeRequest.java
@@ -3,6 +3,6 @@ package com.team.buddyya.certification.dto.request;
 public record EmailCodeRequest(
         String email,
         String univName,
-        int code
+        String code
 ) {
 }

--- a/src/main/java/com/team/buddyya/certification/dto/request/EmailCodeRequest.java
+++ b/src/main/java/com/team/buddyya/certification/dto/request/EmailCodeRequest.java
@@ -2,7 +2,6 @@ package com.team.buddyya.certification.dto.request;
 
 public record EmailCodeRequest(
         String email,
-        String univName,
         String code
 ) {
 }

--- a/src/main/java/com/team/buddyya/certification/exception/CertificateExceptionType.java
+++ b/src/main/java/com/team/buddyya/certification/exception/CertificateExceptionType.java
@@ -5,10 +5,12 @@ import org.springframework.http.HttpStatus;
 
 public enum CertificateExceptionType implements BaseExceptionType {
 
-    CERTIFICATE_FAILED(1001, HttpStatus.UNAUTHORIZED, "인증 중 오류 발생"),
+    CODE_MISMATCH(1000, HttpStatus.UNAUTHORIZED, "Authentication code가 일치하지 않습니다"),
     ALREADY_CERTIFICATED(1002, HttpStatus.UNAUTHORIZED, "이미 인증된 상태입니다"),
-    DUPLICATE_EMAIL(1002, HttpStatus.CONFLICT, "이미 등록된 이메일입니다."),
-    STUDENT_ID_CARD_NOT_FOUND(1003, HttpStatus.NOT_FOUND, "학생증을 찾을 수 없습니다.");
+    DUPLICATED_EMAIL_ADDRESS(1002, HttpStatus.CONFLICT, "이미 등록된 이메일입니다."),
+    STUDENT_EMAIL_NOT_FOUND(1003,HttpStatus.NOT_FOUND, "학생의 이메일을 찾을 수 없습니다."),
+    STUDENT_ID_CARD_NOT_FOUND(1003, HttpStatus.NOT_FOUND, "학생증을 찾을 수 없습니다."),
+    EMAIL_SEND_FAILED(1004, HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/certification/repository/StudentEmailRepository.java
+++ b/src/main/java/com/team/buddyya/certification/repository/StudentEmailRepository.java
@@ -1,0 +1,13 @@
+package com.team.buddyya.certification.repository;
+
+import com.team.buddyya.certification.domain.StudentEmail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface StudentEmailRepository extends JpaRepository<StudentEmail, Long> {
+
+    Optional<StudentEmail> findByEmail(String email);
+}

--- a/src/main/java/com/team/buddyya/certification/service/CertificationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/CertificationService.java
@@ -105,7 +105,7 @@ public class CertificationService {
     public CertificationResponse certificateEmailCode(StudentInfo studentInfo, EmailCodeRequest codeRequest) {
         StudentEmail studentEmail = studentEmailRepository.findByEmail(codeRequest.email())
                 .orElseThrow(() -> new CertificateException(CertificateExceptionType.STUDENT_EMAIL_NOT_FOUND));
-        if (!codeRequest.email().equals(studentEmail.getAuthenticationCode())) {
+        if (!codeRequest.code().equals(studentEmail.getAuthenticationCode())) {
             throw new CertificateException(CertificateExceptionType.CODE_MISMATCH);
         }
         Student student = findStudentService.findByStudentId(studentInfo.id());

--- a/src/main/java/com/team/buddyya/certification/service/CertificationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/CertificationService.java
@@ -38,14 +38,14 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 public class CertificationService {
 
+    private static final int AUTH_CODE_MAX_RANGE = 1_000;
+
     private final FindStudentService findStudentService;
     private final StudentIdCardRepository studentIdCardRepository;
     private final StudentEmailRepository studentEmailRepository;
     private final S3UploadService s3UploadService;
     private final StudentService studentService;
-
     private final JavaMailSender javaMailSender;
-    private static final int AUTH_CODE_MAX_RANGE = 1_000;
 
     @Value("${GOOGLE_SMTP_EMAIL}")
     private String senderEmail;
@@ -60,11 +60,24 @@ public class CertificationService {
 
         message.setFrom(senderEmail);
         message.setRecipients(MimeMessage.RecipientType.TO, mail);
-        message.setSubject("이메일 인증");
-        String body = "";
-        body += "<h3>요청하신 인증 번호입니다.</h3>";
-        body += "<h1>" + number + "</h1>";
-        body += "<h3>감사합니다.</h3>";
+        message.setSubject("[버디야] 대학교 인증을 위한 인증번호를 안내 드립니다.");
+
+        String body = """
+            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px;">
+                <h1 style="text-align: center; color: #333;">대학교 이메일 인증 안내</h1>
+                <p style="font-size: 16px; color: #555;">안녕하세요, <b>고객님</b></p>
+                <p style="font-size: 16px; color: #555;">
+                    아래 발급된 이메일 인증번호를 복사하거나 직접 입력하여 인증을 완료해주세요.
+                </p>
+                <div style="text-align: center; margin: 20px 0;">
+                    <span style="display: inline-block; font-size: 24px; color: #0073e6; font-weight: bold; padding: 10px 20px; border: 1px dashed #0073e6; border-radius: 5px;">
+                        """ + number + """
+                    </span>
+                </div>
+                <p style="font-size: 16px; color: #555; text-align: center;">감사합니다.</p>
+            </div>
+            """;
+
         message.setText(body, "UTF-8", "html");
 
         return message;

--- a/src/main/java/com/team/buddyya/certification/service/CertificationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/CertificationService.java
@@ -44,76 +44,6 @@ public class CertificationService {
     private final StudentIdCardRepository studentIdCardRepository;
     private final StudentEmailRepository studentEmailRepository;
     private final S3UploadService s3UploadService;
-    private final StudentService studentService;
-    private final JavaMailSender javaMailSender;
-
-    @Value("${GOOGLE_SMTP_EMAIL}")
-    private String senderEmail;
-
-    public String generateRandomNumber() {
-        Random rand = new Random();
-        return String.format("%04d", rand.nextInt(AUTH_CODE_MAX_RANGE));
-    }
-
-    public MimeMessage createMail(String mail, String number) throws MessagingException {
-        MimeMessage message = javaMailSender.createMimeMessage();
-
-        message.setFrom(senderEmail);
-        message.setRecipients(MimeMessage.RecipientType.TO, mail);
-        message.setSubject("[버디야] 대학교 인증을 위한 인증번호를 안내 드립니다.");
-
-        String body = """
-            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px;">
-                <h1 style="text-align: center; color: #333;">대학교 이메일 인증 안내</h1>
-                <p style="font-size: 16px; color: #555;">안녕하세요, <b>고객님</b></p>
-                <p style="font-size: 16px; color: #555;">
-                    아래 발급된 이메일 인증번호를 복사하거나 직접 입력하여 인증을 완료해주세요.
-                </p>
-                <div style="text-align: center; margin: 20px 0;">
-                    <span style="display: inline-block; font-size: 24px; color: #0073e6; font-weight: bold; padding: 10px 20px; border: 1px dashed #0073e6; border-radius: 5px;">
-                        """ + number + """
-                    </span>
-                </div>
-                <p style="font-size: 16px; color: #555; text-align: center;">감사합니다.</p>
-            </div>
-            """;
-
-        message.setText(body, "UTF-8", "html");
-
-        return message;
-    }
-
-    public String sendEmail(StudentInfo studentInfo, EmailCertificationRequest emailRequest) {
-        Student student = findStudentService.findByStudentId(studentInfo.id());
-        validateStatusAndEmail(emailRequest, student);
-        String generatedCode = generateRandomNumber();
-        try {
-            MimeMessage message = createMail(emailRequest.email(), generatedCode);
-            javaMailSender.send(message);
-            return generatedCode;
-        } catch (MessagingException | MailException e) {
-            throw new CertificateException(CertificateExceptionType.EMAIL_SEND_FAILED);
-        }
-    }
-
-    private void validateStatusAndEmail(EmailCertificationRequest emailRequest, Student student) {
-        if (student.getIsCertificated()) {
-            throw new CertificateException(CertificateExceptionType.ALREADY_CERTIFICATED);
-        }
-        if (studentService.isDuplicateStudentEmail(emailRequest.email())) {
-            throw new CertificateException(CertificateExceptionType.DUPLICATED_EMAIL_ADDRESS);
-        }
-    }
-
-    public CertificationResponse saveCode(String email, String generatedCode) {
-        StudentEmail studentEmail = studentEmailRepository.findByEmail(email)
-                .orElseGet(() -> new StudentEmail(email, generatedCode));
-        if (studentEmail.getId() != null) {
-            studentEmail.updateAuthenticationCode(generatedCode);
-        }
-        studentEmailRepository.save(studentEmail);
-        return CertificationResponse.from(true);
-    }
 
     public CertificationResponse certificateEmailCode(StudentInfo studentInfo, EmailCodeRequest codeRequest) {
         StudentEmail studentEmail = studentEmailRepository.findByEmail(codeRequest.email())
@@ -123,6 +53,16 @@ public class CertificationService {
         }
         Student student = findStudentService.findByStudentId(studentInfo.id());
         updateCertification(codeRequest, student);
+        return CertificationResponse.from(true);
+    }
+
+    public CertificationResponse saveCode(String email, String generatedCode) {
+        StudentEmail studentEmail = studentEmailRepository.findByEmail(email)
+                .orElseGet(() -> new StudentEmail(email, generatedCode));
+        if (studentEmail.getId() != null) {
+            studentEmail.updateAuthenticationCode(generatedCode);
+        }
+        studentEmailRepository.save(studentEmail);
         return CertificationResponse.from(true);
     }
 

--- a/src/main/java/com/team/buddyya/certification/service/CertificationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/CertificationService.java
@@ -3,6 +3,7 @@ package com.team.buddyya.certification.service;
 import static com.team.buddyya.common.domain.S3DirectoryName.STUDENT_ID_CARD;
 
 import com.team.buddyya.auth.domain.StudentInfo;
+import com.team.buddyya.certification.domain.StudentEmail;
 import com.team.buddyya.certification.domain.StudentIdCard;
 import com.team.buddyya.certification.dto.request.EmailCertificationRequest;
 import com.team.buddyya.certification.dto.request.EmailCodeRequest;
@@ -12,17 +13,22 @@ import com.team.buddyya.certification.dto.response.CertificationStatusResponse;
 import com.team.buddyya.certification.dto.response.StudentIdCardResponse;
 import com.team.buddyya.certification.exception.CertificateException;
 import com.team.buddyya.certification.exception.CertificateExceptionType;
+import com.team.buddyya.certification.repository.StudentEmailRepository;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
 import com.team.buddyya.student.service.StudentService;
-import com.univcert.api.UnivCert;
-import java.io.IOException;
-import java.util.Map;
+
 import java.util.Optional;
+import java.util.Random;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,22 +40,46 @@ public class CertificationService {
 
     private final FindStudentService findStudentService;
     private final StudentIdCardRepository studentIdCardRepository;
+    private final StudentEmailRepository studentEmailRepository;
     private final S3UploadService s3UploadService;
     private final StudentService studentService;
 
-    @Value("${univcert.api.key}")
-    private String univcertApiKey;
+    private final JavaMailSender javaMailSender;
+    private static final int AUTH_CODE_MAX_RANGE = 1_000;
 
-    public CertificationResponse certificateEmail(StudentInfo studentInfo, EmailCertificationRequest emailRequest) {
+    @Value("${GOOGLE_SMTP_EMAIL}")
+    private String senderEmail;
+
+    public String generateRandomNumber() {
+        Random rand = new Random();
+        return String.format("%04d", rand.nextInt(AUTH_CODE_MAX_RANGE));
+    }
+
+    public MimeMessage createMail(String mail, String number) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.setFrom(senderEmail);
+        message.setRecipients(MimeMessage.RecipientType.TO, mail);
+        message.setSubject("이메일 인증");
+        String body = "";
+        body += "<h3>요청하신 인증 번호입니다.</h3>";
+        body += "<h1>" + number + "</h1>";
+        body += "<h3>감사합니다.</h3>";
+        message.setText(body, "UTF-8", "html");
+
+        return message;
+    }
+
+    public String sendEmail(StudentInfo studentInfo, EmailCertificationRequest emailRequest) {
         Student student = findStudentService.findByStudentId(studentInfo.id());
         validateStatusAndEmail(emailRequest, student);
+        String generatedCode = generateRandomNumber();
         try {
-            Map<String, Object> univCertResponse = UnivCert.certify(univcertApiKey, emailRequest.email(),
-                    emailRequest.univName(), true);
-            boolean isSuccess = (Boolean) univCertResponse.get("success");
-            return CertificationResponse.from(isSuccess);
-        } catch (IOException e) {
-            throw new CertificateException(CertificateExceptionType.CERTIFICATE_FAILED);
+            MimeMessage message = createMail(emailRequest.email(), generatedCode);
+            javaMailSender.send(message);
+            return generatedCode;
+        } catch (MessagingException | MailException e) {
+            throw new CertificateException(CertificateExceptionType.EMAIL_SEND_FAILED);
         }
     }
 
@@ -58,24 +88,29 @@ public class CertificationService {
             throw new CertificateException(CertificateExceptionType.ALREADY_CERTIFICATED);
         }
         if (studentService.isDuplicateStudentEmail(emailRequest.email())) {
-            throw new CertificateException(CertificateExceptionType.DUPLICATE_EMAIL);
+            throw new CertificateException(CertificateExceptionType.DUPLICATED_EMAIL_ADDRESS);
         }
     }
 
-    public CertificationResponse certificateEmailCode(StudentInfo studentInfo, EmailCodeRequest codeRequest) {
-        try {
-            Map<String, Object> univCertResponse = UnivCert.certifyCode(univcertApiKey, codeRequest.email(),
-                    codeRequest.univName(), codeRequest.code());
-            Boolean isSuccess = (Boolean) univCertResponse.get("success");
-            if (isSuccess) {
-                Student student = findStudentService.findByStudentId(studentInfo.id());
-                updateCertification(codeRequest, student);
-            }
-            UnivCert.clear(univcertApiKey);
-            return CertificationResponse.from(isSuccess);
-        } catch (IOException e) {
-            throw new CertificateException(CertificateExceptionType.CERTIFICATE_FAILED);
+    public CertificationResponse saveCode(String email, String generatedCode) {
+        StudentEmail studentEmail = studentEmailRepository.findByEmail(email)
+                .orElseGet(() -> new StudentEmail(email, generatedCode));
+        if (studentEmail.getId() != null) {
+            studentEmail.updateAuthenticationCode(generatedCode);
         }
+        studentEmailRepository.save(studentEmail);
+        return CertificationResponse.from(true);
+    }
+
+    public CertificationResponse certificateEmailCode(StudentInfo studentInfo, EmailCodeRequest codeRequest) {
+        StudentEmail studentEmail = studentEmailRepository.findByEmail(codeRequest.email())
+                .orElseThrow(() -> new CertificateException(CertificateExceptionType.STUDENT_EMAIL_NOT_FOUND));
+        if (!codeRequest.email().equals(studentEmail.getAuthenticationCode())) {
+            throw new CertificateException(CertificateExceptionType.CODE_MISMATCH);
+        }
+        Student student = findStudentService.findByStudentId(studentInfo.id());
+        updateCertification(codeRequest, student);
+        return CertificationResponse.from(true);
     }
 
     private void updateCertification(EmailCodeRequest codeRequest, Student student) {

--- a/src/main/java/com/team/buddyya/certification/service/EmailSendService.java
+++ b/src/main/java/com/team/buddyya/certification/service/EmailSendService.java
@@ -1,0 +1,87 @@
+package com.team.buddyya.certification.service;
+
+import com.team.buddyya.auth.domain.StudentInfo;
+import com.team.buddyya.certification.dto.request.EmailCertificationRequest;
+import com.team.buddyya.certification.exception.CertificateException;
+import com.team.buddyya.certification.exception.CertificateExceptionType;
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.service.FindStudentService;
+import com.team.buddyya.student.service.StudentService;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailSendService {
+
+    private static final int AUTH_CODE_MAX_RANGE = 1_000;
+
+    private final JavaMailSender javaMailSender;
+    private final StudentService studentService;
+    private final FindStudentService findStudentService;
+
+    @Value("${GOOGLE_SMTP_EMAIL}")
+    private String senderEmail;
+
+    public String sendEmail(StudentInfo studentInfo, EmailCertificationRequest emailRequest) {
+        Student student = findStudentService.findByStudentId(studentInfo.id());
+        validateStatusAndEmail(emailRequest, student);
+        String generatedCode = generateRandomNumber();
+        try {
+            MimeMessage message = createMail(emailRequest.email(), generatedCode);
+            javaMailSender.send(message);
+            return generatedCode;
+        } catch (MessagingException | MailException e) {
+            throw new CertificateException(CertificateExceptionType.EMAIL_SEND_FAILED);
+        }
+    }
+
+    private void validateStatusAndEmail(EmailCertificationRequest emailRequest, Student student) {
+        if (student.getIsCertificated()) {
+            throw new CertificateException(CertificateExceptionType.ALREADY_CERTIFICATED);
+        }
+        if (studentService.isDuplicateStudentEmail(emailRequest.email())) {
+            throw new CertificateException(CertificateExceptionType.DUPLICATED_EMAIL_ADDRESS);
+        }
+    }
+
+    public MimeMessage createMail(String mail, String number) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.setFrom(senderEmail);
+        message.setRecipients(MimeMessage.RecipientType.TO, mail);
+        message.setSubject("[버디야] 대학교 인증을 위한 인증번호를 안내 드립니다.");
+
+        String body = """
+            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px;">
+                <h1 style="text-align: center; color: #333;">대학교 이메일 인증 안내</h1>
+                <p style="font-size: 16px; color: #555;">안녕하세요, <b>고객님</b></p>
+                <p style="font-size: 16px; color: #555;">
+                    아래 발급된 이메일 인증번호를 복사하거나 직접 입력하여 인증을 완료해주세요.
+                </p>
+                <div style="text-align: center; margin: 20px 0;">
+                    <span style="display: inline-block; font-size: 24px; color: #0073e6; font-weight: bold; padding: 10px 20px; border: 1px dashed #0073e6; border-radius: 5px;">
+                        """ + number + """
+                    </span>
+                </div>
+                <p style="font-size: 16px; color: #555; text-align: center;">감사합니다.</p>
+            </div>
+            """;
+
+        message.setText(body, "UTF-8", "html");
+
+        return message;
+    }
+
+    private String generateRandomNumber() {
+        Random rand = new Random();
+        return String.format("%04d", rand.nextInt(AUTH_CODE_MAX_RANGE));
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -2,7 +2,7 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/buddy_ya
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
-spring.datasource.password=1234
+spring.datasource.password=1942
 # JPA settings
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,16 @@ spring.profiles.active=${ACTIVE}
 auth.jwt.secret=vItzBpfi0YGTCB55MTBTdFgy2RsUe8ZmabUE2Ls/A3k=
 auth.jwt.access.expiration=86400
 auth.jwt.refresh.expiration=5184000
-# univcert setting
-univcert.api.key=${UNIVCERT_API_KEY}
+# smtp setting
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${GOOGLE_SMTP_EMAIL}
+spring.mail.password=${GOOGLE_SMTP_PASSWORD}
+spring.mail.properties.mail.debug=true
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.auth=true
 # AWS
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.region.auto=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,6 @@ spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=${GOOGLE_SMTP_EMAIL}
 spring.mail.password=${GOOGLE_SMTP_PASSWORD}
-spring.mail.properties.mail.debug=true
 spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true


### PR DESCRIPTION
## 📌 관련 이슈
[대학교 이메일 인증을 외부 api가 아닌 자체적으로 smtp를 사용하여 구현](https://github.com/buddy-ya/be/issues/67)[#67]

<br><br>

## 🛠️ 작업 내용

기존 저희가 사용한 대학교 이메일 인증 api univcert는 두가지 치명적인 문제점을 가지고 있습니다.
1. 인증코드가 4자리가 아닌 코드가 간다
2. 스팸메일로 처리되어 유저가 직접 스팸 메일함에서 코드를 찾아야 한다.
이를 개선하기 위해서 univcert를 사용하지 않고 자체적으로 smtp를 사용하여 이메일 인증을 구현해보았습니다.

<br><br>

## 🎯 리뷰 포인트

- 코드 컨벤션은 잘 지켜졌는가?
-  각 서비스가 하나의 역할을 하고 있는가?

### 고민해봐야할 점🤔
일단 임시로 구글 smtp(무료)를 사용하여 구현하였고, 추후에 Amazon SES를 사용하여 구현해봐야할 것 같습니다.
그리고 원래는 unicvert에서 대학교 이름을 요구해서 requestDTO에 대학교 이름을 보냈었지만 이제는 필요하지 않아
제거하였습니다. 

<br><br>

## 📎 커밋 범위 링크

<br><br>
