### PR TITLE
feat: 채팅방 사진 전송, 채팅방 사용되지 않는 세션 종료, 수정 사항 변경

### DIFF
--- a/src/main/java/com/team/buddyya/BuddyyaApplication.java
+++ b/src/main/java/com/team/buddyya/BuddyyaApplication.java
@@ -3,13 +3,15 @@ package com.team.buddyya;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BuddyyaApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BuddyyaApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BuddyyaApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/team/buddyya/auth/jwt/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/WebSocketAuthInterceptor.java
@@ -35,6 +35,7 @@ public class WebSocketAuthInterceptor implements HandshakeInterceptor {
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) {
         try {
             validateHandshake(request, attributes);
+            attributes.put("timeout", System.currentTimeMillis() + 40000);
             return true;
         } catch (IllegalArgumentException e) {
             log.warn("Handshake failed: {}", e.getMessage());

--- a/src/main/java/com/team/buddyya/auth/jwt/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/team/buddyya/auth/jwt/WebSocketAuthInterceptor.java
@@ -21,6 +21,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WebSocketAuthInterceptor implements HandshakeInterceptor {
 
+    private static final long SESSION_TIMEOUT = 45000;
     private static final String ERROR_UNAUTHORIZED = "권한 없음";
     private static final String ERROR_INTERNAL_SERVER = "핸드셰이크 중 내부 서버 오류 발생";
     private static final String ERROR_INVALID_JWT = "유효하지 않은 JWT 토큰";
@@ -35,7 +36,7 @@ public class WebSocketAuthInterceptor implements HandshakeInterceptor {
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) {
         try {
             validateHandshake(request, attributes);
-            attributes.put("timeout", System.currentTimeMillis() + 40000);
+            attributes.put("timeout", System.currentTimeMillis() + SESSION_TIMEOUT);
             return true;
         } catch (IllegalArgumentException e) {
             log.warn("Handshake failed: {}", e.getMessage());

--- a/src/main/java/com/team/buddyya/chatting/controller/ChatController.java
+++ b/src/main/java/com/team/buddyya/chatting/controller/ChatController.java
@@ -57,11 +57,11 @@ public class ChatController {
     }
 
 
-    @PostMapping("/{roomId}/images")
+    @PostMapping("/{roomId}/image")
     public ResponseEntity<Void> uploadImages(@PathVariable("roomId") Long chatroomId,
                                              @AuthenticationPrincipal CustomUserDetails userDetails,
                                              @ModelAttribute ChatImageRequest request) {
-        chatService.chatUploadImages(chatroomId, userDetails.getStudentInfo(), request);
+        chatService.chatUploadImage(chatroomId, userDetails.getStudentInfo(), request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/controller/ChatController.java
+++ b/src/main/java/com/team/buddyya/chatting/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.team.buddyya.chatting.controller;
 
 import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.chatting.dto.request.ChatImageRequest;
 import com.team.buddyya.chatting.dto.request.CreateChatroomRequest;
 import com.team.buddyya.chatting.dto.response.ChatMessageListResponse;
 import com.team.buddyya.chatting.dto.response.ChatroomResponse;
@@ -53,5 +54,14 @@ public class ChatController {
             @PathVariable("roomId") Long chatroomId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(chatService.leaveChatroom(chatroomId, userDetails.getStudentInfo()));
+    }
+
+
+    @PostMapping("/{roomId}/images")
+    public ResponseEntity<Void> uploadImages(@PathVariable("roomId") Long chatroomId,
+                                             @AuthenticationPrincipal CustomUserDetails userDetails,
+                                             @ModelAttribute ChatImageRequest request) {
+        chatService.chatUploadImages(chatroomId, userDetails.getStudentInfo(), request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/domain/Chat.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/Chat.java
@@ -30,8 +30,12 @@ public class Chat extends CreatedTime {
     @Column(columnDefinition = "TEXT")
     private String message;
 
+    @Enumerated(EnumType.STRING)
+    private MessageType type;
+
     @Builder
-    public Chat(Chatroom chatroom, Student student, String message) {
+    public Chat(MessageType type, Chatroom chatroom, Student student, String message) {
+        this.type = type;
         this.chatroom = chatroom;
         this.student = student;
         this.message = message;

--- a/src/main/java/com/team/buddyya/chatting/domain/Chatroom.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/Chatroom.java
@@ -22,10 +22,6 @@ public class Chatroom extends CreatedTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long postId;
-
-    private String name;
-
     private String lastMessage;
 
     private LocalDateTime lastMessageTime;
@@ -37,13 +33,11 @@ public class Chatroom extends CreatedTime {
     private List<Chat> chats;
 
     @Builder
-    public Chatroom(Long postId, String name) {
+    public Chatroom() {
         this.chatroomStudents = new ArrayList<>();
         this.chats = new ArrayList<>();
         lastMessage = null;
         lastMessageTime = null;
-        this.postId = postId;
-        this.name = name;
     }
 
     public void updateLastMessage(String message) {

--- a/src/main/java/com/team/buddyya/chatting/domain/Chatroom.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/Chatroom.java
@@ -33,11 +33,11 @@ public class Chatroom extends CreatedTime {
     private List<Chat> chats;
 
     @Builder
-    public Chatroom() {
+    public Chatroom(LocalDateTime createdTime) {
         this.chatroomStudents = new ArrayList<>();
         this.chats = new ArrayList<>();
         lastMessage = null;
-        lastMessageTime = null;
+        lastMessageTime = createdTime;
     }
 
     public void updateLastMessage(String message) {

--- a/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
@@ -29,15 +29,15 @@ public class ChatroomStudent {
     @Column(name = "unread_count")
     private int unreadCount;
 
-    @Column(name = "left")
-    private Boolean isLeft;
+    @Column(name = "exited")
+    private Boolean isExited;
 
     @Builder
     public ChatroomStudent(Student student, Chatroom chatroom) {
         this.student = student;
         this.chatroom = chatroom;
         this.unreadCount = 0;
-        this.isLeft = false;
+        this.isExited = false;
     }
 
     public void increaseUnreadCount() {
@@ -49,7 +49,7 @@ public class ChatroomStudent {
     }
 
     public void updateLeave() {
-        this.isLeft = true;
+        this.isExited = true;
     }
 }
 

--- a/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
@@ -48,7 +48,7 @@ public class ChatroomStudent {
         this.unreadCount = 0;
     }
 
-    public void updateLeave() {
+    public void updateIsExited() {
         this.isExited = true;
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
@@ -31,15 +29,15 @@ public class ChatroomStudent {
     @Column(name = "unread_count")
     private int unreadCount;
 
-    @Column(name = "leave_time")
-    private LocalDateTime leaveTime;
+    @Column(name = "left")
+    private Boolean isLeft;
 
     @Builder
     public ChatroomStudent(Student student, Chatroom chatroom) {
         this.student = student;
         this.chatroom = chatroom;
         this.unreadCount = 0;
-        this.leaveTime = LocalDateTime.now();
+        this.isLeft = false;
     }
 
     public void increaseUnreadCount() {
@@ -50,8 +48,8 @@ public class ChatroomStudent {
         this.unreadCount = 0;
     }
 
-    public void updateLeaveTime() {
-        this.leaveTime = LocalDateTime.now();
+    public void updateLeave() {
+        this.isLeft = true;
     }
 }
 

--- a/src/main/java/com/team/buddyya/chatting/domain/MessageType.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/MessageType.java
@@ -1,5 +1,5 @@
 package com.team.buddyya.chatting.domain;
 
 public enum MessageType {
-    ENTER, TALK
+    ENTER, TALK, IMAGE
 }

--- a/src/main/java/com/team/buddyya/chatting/domain/MessageType.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/MessageType.java
@@ -1,5 +1,5 @@
 package com.team.buddyya.chatting.domain;
 
 public enum MessageType {
-    ENTER, TALK, IMAGE
+    TALK, IMAGE
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/request/ChatImageRequest.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/request/ChatImageRequest.java
@@ -2,10 +2,8 @@ package com.team.buddyya.chatting.dto.request;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 public record ChatImageRequest(
-        List<MultipartFile> images,
+        MultipartFile image,
         Long tempId
 ) {
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/request/ChatImageRequest.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/request/ChatImageRequest.java
@@ -1,0 +1,11 @@
+package com.team.buddyya.chatting.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record ChatImageRequest(
+        List<MultipartFile> images,
+        Long tempId
+) {
+}

--- a/src/main/java/com/team/buddyya/chatting/dto/request/ChatMessage.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/request/ChatMessage.java
@@ -1,6 +1,7 @@
 package com.team.buddyya.chatting.dto.request;
 
 import com.team.buddyya.chatting.domain.MessageType;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,6 +17,16 @@ public class ChatMessage {
     private String message;
     private Long tempId;
     private LocalDateTime time;
+
+    @Builder
+    public ChatMessage(MessageType type, Long roomId, Long userId, String message, Long tempId, LocalDateTime time) {
+        this.type = type;
+        this.roomId = roomId;
+        this.userId = userId;
+        this.message = message;
+        this.tempId = tempId;
+        this.time = time;
+    }
 
     public void setTime(LocalDateTime time) {
         this.time = time;

--- a/src/main/java/com/team/buddyya/chatting/dto/request/CreateChatroomRequest.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/request/CreateChatroomRequest.java
@@ -1,8 +1,6 @@
 package com.team.buddyya.chatting.dto.request;
 
 public record CreateChatroomRequest(
-        Long buddyId,
-        Long feedId,
-        String feedName
+        Long buddyId
 ) {
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/ChatMessageResponse.java
@@ -1,12 +1,14 @@
 package com.team.buddyya.chatting.dto.response;
 
 import com.team.buddyya.chatting.domain.Chat;
+import com.team.buddyya.chatting.domain.MessageType;
 
 import java.time.LocalDateTime;
 
 public record ChatMessageResponse(
         Long id,
         Long senderId,
+        MessageType type,
         String message,
         LocalDateTime createdDate
 ) {
@@ -15,6 +17,7 @@ public record ChatMessageResponse(
         return new ChatMessageResponse(
                 chat.getId(),
                 chat.getStudent().getId(),
+                chat.getType(),
                 chat.getMessage(),
                 chat.getCreatedDate()
         );

--- a/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomResponse.java
@@ -12,10 +12,10 @@ public record ChatroomResponse(
         String profileImageUrl,
         String lastMessage,
         LocalDateTime lastMessageDate,
-        boolean isBuddyLeft
+        boolean isBuddyExited
 ) {
 
-    public static ChatroomResponse from(Chatroom chatroom, String name, ChatroomStudent chatroomStudent, String buddyProfileImage, boolean isBuddyLeft) {
-        return new ChatroomResponse(chatroom.getId(), name, chatroomStudent.getUnreadCount(), buddyProfileImage, chatroom.getLastMessage(), chatroom.getLastMessageTime(), isBuddyLeft);
+    public static ChatroomResponse from(Chatroom chatroom, String name, ChatroomStudent chatroomStudent, String buddyProfileImage, boolean isBuddyLeave) {
+        return new ChatroomResponse(chatroom.getId(), name, chatroomStudent.getUnreadCount(), buddyProfileImage, chatroom.getLastMessage(), chatroom.getLastMessageTime(), isBuddyLeave);
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomResponse.java
@@ -11,10 +11,11 @@ public record ChatroomResponse(
         int unreadCount,
         String profileImageUrl,
         String lastMessage,
-        LocalDateTime lastMessageDate
+        LocalDateTime lastMessageDate,
+        boolean isBuddyLeft
 ) {
 
-    public static ChatroomResponse from(Chatroom chatroom, ChatroomStudent chatroomStudent, String buddyProfileImage) {
-        return new ChatroomResponse(chatroom.getId(), chatroom.getName(), chatroomStudent.getUnreadCount(), buddyProfileImage, chatroom.getLastMessage(), chatroom.getLastMessageTime());
+    public static ChatroomResponse from(Chatroom chatroom, String name, ChatroomStudent chatroomStudent, String buddyProfileImage, boolean isBuddyLeft) {
+        return new ChatroomResponse(chatroom.getId(), name, chatroomStudent.getUnreadCount(), buddyProfileImage, chatroom.getLastMessage(), chatroom.getLastMessageTime(), isBuddyLeft);
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/response/CreateChatroomResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/CreateChatroomResponse.java
@@ -5,21 +5,21 @@ import com.team.buddyya.student.domain.Student;
 
 public record CreateChatroomResponse(
         Long id,
-        String name,
         Long buddyId,
         String buddyName,
         String country,
-        String profileImageUrl
+        String profileImageUrl,
+        boolean isNew
 ) {
 
-    public static CreateChatroomResponse from(Chatroom chatroom, Student buddy) {
+    public static CreateChatroomResponse from(Chatroom chatroom, Student buddy, boolean isNew) {
         return new CreateChatroomResponse(
                 chatroom.getId(),
-                chatroom.getName(),
                 buddy.getId(),
                 buddy.getName(),
                 buddy.getCountry(),
-                buddy.getProfileImage().getUrl()
+                buddy.getProfileImage().getUrl(),
+                isNew
         );
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/response/CreateChatroomResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/CreateChatroomResponse.java
@@ -6,7 +6,7 @@ import com.team.buddyya.student.domain.Student;
 public record CreateChatroomResponse(
         Long id,
         Long buddyId,
-        String buddyName,
+        String name,
         String country,
         String profileImageUrl,
         boolean isNew

--- a/src/main/java/com/team/buddyya/chatting/repository/ChatRepository.java
+++ b/src/main/java/com/team/buddyya/chatting/repository/ChatRepository.java
@@ -6,9 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
-
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
-    Page<Chat> findByChatroomAndCreatedDateAfter(Chatroom chatroom, LocalDateTime leaveTime, Pageable pageable);
+    Page<Chat> findByChatroom(Chatroom chatroom, Pageable pageable);
+
 }

--- a/src/main/java/com/team/buddyya/chatting/repository/ChatroomRepository.java
+++ b/src/main/java/com/team/buddyya/chatting/repository/ChatroomRepository.java
@@ -11,7 +11,6 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
     @Query("SELECT c FROM Chatroom c " +
             "JOIN c.chatroomStudents s1 ON s1.student.id = :userId " +
-            "JOIN c.chatroomStudents s2 ON s2.student.id = :buddyId " +
-            "WHERE c.postId = :postId")
-    Optional<Chatroom> findByUserAndBuddyAndPostId(@Param("userId") Long userId, @Param("buddyId") Long buddyId, @Param("postId") Long postId);
+            "JOIN c.chatroomStudents s2 ON s2.student.id = :buddyId")
+    Optional<Chatroom> findByUserAndBuddy(@Param("userId") Long userId, @Param("buddyId") Long buddyId);
 }

--- a/src/main/java/com/team/buddyya/chatting/service/ChatHandler.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatHandler.java
@@ -45,6 +45,17 @@ public class ChatHandler extends TextWebSocketHandler {
     }
 
     @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        Long userId = (Long) session.getAttributes().get("userId");
+        Long roomId = (Long) session.getAttributes().get("roomId");
+        if (userId == null || roomId == null) {
+            session.close(CloseStatus.BAD_DATA);
+            return;
+        }
+        service.addSessionToRoom(roomId, session);
+    }
+
+    @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) {
         log.error("세션 {}의 전송 오류: {}", session.getId(), exception.getMessage());
         closeSession(session, ERROR_TRANSPORT);

--- a/src/main/java/com/team/buddyya/chatting/service/ChatHandler.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatHandler.java
@@ -32,9 +32,14 @@ public class ChatHandler extends TextWebSocketHandler {
         try {
             String payload = (String) message.getPayload();
             log.info("수신된 페이로드: {}", payload);
+            if ("PONG".equalsIgnoreCase(payload.trim())) {
+                service.updateLastPongTimestamp(session);
+                log.info("세션 {}으로부터 PONG 수신.", session.getId());
+                return;
+            }
             ChatMessage chatMessage = mapper.readValue(payload, ChatMessage.class);
             chatMessage.setTime(LocalDateTime.now());
-            service.handleAction(session, chatMessage);
+            service.handleAction(chatMessage);
         } catch (IllegalArgumentException e) {
             handleClientError(session, ERROR_INVALID_MESSAGE_FORMAT);
         } catch (IOException e) {

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -6,6 +6,7 @@ import com.team.buddyya.chatting.domain.Chat;
 import com.team.buddyya.chatting.domain.Chatroom;
 import com.team.buddyya.chatting.domain.ChatroomStudent;
 import com.team.buddyya.chatting.domain.MessageType;
+import com.team.buddyya.chatting.dto.request.ChatImageRequest;
 import com.team.buddyya.chatting.dto.request.ChatMessage;
 import com.team.buddyya.chatting.dto.request.CreateChatroomRequest;
 import com.team.buddyya.chatting.dto.response.*;
@@ -14,6 +15,7 @@ import com.team.buddyya.chatting.exception.ChatExceptionType;
 import com.team.buddyya.chatting.repository.ChatRepository;
 import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.chatting.repository.ChatroomStudentRepository;
+import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,8 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.team.buddyya.common.domain.S3DirectoryName.CHAT_IMAGE;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -38,11 +42,13 @@ public class ChatService {
 
     private static final String ERROR_CHATROOM_NOT_FOUND = "채팅방을 찾을 수 없습니다.";
     private static final String CHATROOM_LEAVE_SUCCESS_MESSAGE = "채팅방을 나갔습니다.";
+    private static final String IMAGE_SENT_MESSAGE = "사진을 보냈습니다";
 
     private final ObjectMapper mapper;
-    private final ChatroomRepository chatRoomRepository;
     private final FindStudentService findStudentService;
+    private final S3UploadService s3UploadService;
     private final ChatRepository chatRepository;
+    private final ChatroomRepository chatRoomRepository;
     private final ChatroomStudentRepository chatroomStudentRepository;
     private final Map<Long, Set<WebSocketSession>> sessionsPerRoom = new HashMap<>();
 
@@ -84,46 +90,45 @@ public class ChatService {
         if (chatMessage.getType().equals(MessageType.ENTER)) {
             sessionsPerRoom.computeIfAbsent(chatRoom.getId(), k -> new HashSet<>()).add(session);
         } else if (chatMessage.getType().equals(MessageType.TALK)) {
-            saveMessageAndHandleUnreadCount(chatMessage, session);
-            sendMessageToRoom(chatRoom.getId(), chatMessage, session);
+            saveMessageAndHandleUnreadCount(chatMessage);
+            sendMessageToRoom(chatRoom.getId(), chatMessage);
         }
     }
 
-    private void saveMessageAndHandleUnreadCount(ChatMessage chatMessage, WebSocketSession senderSession) {
-        Student sender = findStudentService.findByStudentId(chatMessage.getUserId());
+    private void saveMessageAndHandleUnreadCount(ChatMessage chatMessage) {
         Chatroom chatroom = chatRoomRepository.findById(chatMessage.getRoomId())
                 .orElseThrow(() -> new IllegalArgumentException(ERROR_CHATROOM_NOT_FOUND));
+        Student sender = findStudentService.findByStudentId(chatMessage.getUserId());
         Chat chat = Chat.builder()
+                .type(chatMessage.getType())
                 .chatroom(chatroom)
                 .student(sender)
                 .message(chatMessage.getMessage())
                 .build();
-        chatroom.updateLastMessage(chatMessage.getMessage());
+        String lastMessageContent = chatMessage.getType() == MessageType.IMAGE
+                ? IMAGE_SENT_MESSAGE : chatMessage.getMessage();
+        chatroom.updateLastMessage(lastMessageContent);
         chatRepository.save(chat);
-        updateUnreadCountForChatroom(chatroom, senderSession);
+        updateUnreadCountForChatroom(chatroom, sender.getId());
     }
 
-    private void updateUnreadCountForChatroom(Chatroom chatroom, WebSocketSession senderSession) {
+    private void updateUnreadCountForChatroom(Chatroom chatroom, Long senderId) {
         Set<WebSocketSession> sessions = sessionsPerRoom.getOrDefault(chatroom.getId(), Collections.emptySet());
-        Long senderId = (Long) senderSession.getAttributes().get("userId");
         for (ChatroomStudent chatroomStudent : chatroom.getChatroomStudents()) {
             Long receiverId = chatroomStudent.getStudent().getId();
-            if (!senderId.equals(receiverId) && !isReceiverConnected(sessions, receiverId)) {
+            boolean isReceiverConnected = sessions.stream()
+                    .anyMatch(session -> receiverId.equals(session.getAttributes().get("userId")));
+            if (!senderId.equals(receiverId) && !isReceiverConnected) {
                 chatroomStudent.increaseUnreadCount();
                 chatroomStudentRepository.save(chatroomStudent);
             }
         }
     }
 
-    private boolean isReceiverConnected(Set<WebSocketSession> sessions, Long receiverId) {
-        return sessions.stream()
-                .anyMatch(session -> receiverId.equals(session.getAttributes().get("userId")));
-    }
-
-    public void sendMessageToRoom(Long roomId, ChatMessage message, WebSocketSession senderSession) {
+    public void sendMessageToRoom(Long roomId, ChatMessage message) {
         Set<WebSocketSession> sessions = sessionsPerRoom.get(roomId);
         if (sessions != null) {
-            sessions.removeIf(session -> !session.equals(senderSession) && !sendMessage(session, message));
+            sessions.removeIf(session -> !sendMessage(session, message));
         }
     }
 
@@ -192,4 +197,24 @@ public class ChatService {
         chatroomStudent.resetUnreadCount();
         return LeaveChatroomResponse.from(CHATROOM_LEAVE_SUCCESS_MESSAGE);
     }
+
+    public void chatUploadImages(Long roomId, StudentInfo studentInfo, ChatImageRequest request) {
+        List<String> imageUrls = request.images()
+                .stream()
+                .map(image -> s3UploadService.uploadFile(CHAT_IMAGE.getDirectoryName(), image))
+                .collect(Collectors.toList());
+        String imageMessages = String.join(",", imageUrls);
+        ChatMessage chatMessage = ChatMessage.builder()
+                .type(MessageType.IMAGE)
+                .roomId(roomId)
+                .tempId(request.tempId())
+                .message(imageMessages)
+                .userId(studentInfo.id())
+                .time(LocalDateTime.now())
+                .build();
+        saveMessageAndHandleUnreadCount(chatMessage);
+        sendMessageToRoom(roomId, chatMessage);
+    }
+
 }
+

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.socket.TextMessage;
@@ -158,7 +157,7 @@ public class ChatService {
     public List<ChatroomResponse> getChatRooms(StudentInfo studentInfo) {
         Student student = findStudentService.findByStudentId(studentInfo.id());
         return student.getChatroomStudents().stream()
-                .filter(chatroomStudent -> !chatroomStudent.getIsLeft())
+                .filter(chatroomStudent -> !chatroomStudent.getIsExited())
                 .map(chatroomStudent -> createChatroomResponse(chatroomStudent))
                 .filter(Objects::nonNull)
                 .sorted((a, b) -> b.lastMessageDate().compareTo(a.lastMessageDate()))
@@ -171,10 +170,10 @@ public class ChatService {
         if (buddy == null) {
             return ChatroomResponse.from(chatroom, null, chatroomStudent, null, true);
         }
-        boolean isBuddyLeft = chatroom.getChatroomStudents().stream()
+        boolean isBuddyExited = chatroom.getChatroomStudents().stream()
                 .filter(cs -> !cs.getStudent().getId().equals(chatroomStudent.getStudent().getId()))
-                .anyMatch(ChatroomStudent::getIsLeft);
-        return ChatroomResponse.from(chatroom, buddy.getName(), chatroomStudent, buddy.getProfileImage().getUrl(), isBuddyLeft);
+                .anyMatch(ChatroomStudent::getIsExited);
+        return ChatroomResponse.from(chatroom, buddy.getName(), chatroomStudent, buddy.getProfileImage().getUrl(), isBuddyExited);
     }
 
     private Student getBuddyFromChatroom(Student student, Chatroom chatroom) {
@@ -223,7 +222,7 @@ public class ChatService {
         log.info("Room ID {}에 새로운 세션 추가. 현재 세션 수: {}", roomId, sessionsPerRoom.get(roomId).size());
     }
 
-    @Scheduled(fixedRate = 30000)
+    //    @Scheduled(fixedRate = 30000)
     public void sendPingMessages() {
         log.info("모든 WebSocket 세션에 Ping 메시지를 전송합니다.");
         long currentTime = System.currentTimeMillis();

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -189,6 +189,7 @@ public class ChatService {
                 .orElseThrow(() -> new ChatException(ChatExceptionType.CHATROOM_NOT_FOUND));
         ChatroomStudent chatroomStudent = chatroomStudentRepository.findByChatroomAndStudentId(chatroom, studentInfo.id())
                 .orElseThrow(() -> new ChatException(ChatExceptionType.USER_NOT_PART_OF_CHATROOM));
+        chatroomStudent.resetUnreadCount();
         Page<Chat> chats = chatRepository.findByChatroom(chatroom, pageable);
         Page<ChatMessageResponse> chatResponses = chats.map(ChatMessageResponse::from);
         return ChatMessageListResponse.from(chatResponses);
@@ -199,7 +200,7 @@ public class ChatService {
                 .orElseThrow(() -> new ChatException(ChatExceptionType.CHATROOM_NOT_FOUND));
         ChatroomStudent chatroomStudent = chatroomStudentRepository.findByChatroomAndStudentId(chatroom, studentInfo.id())
                 .orElseThrow(() -> new ChatException(ChatExceptionType.USER_NOT_PART_OF_CHATROOM));
-        chatroomStudent.updateLeave();
+        chatroomStudent.updateIsExited();
         return LeaveChatroomResponse.from(CHATROOM_LEAVE_SUCCESS_MESSAGE);
     }
 

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -204,7 +204,7 @@ public class ChatService {
         return LeaveChatroomResponse.from(CHATROOM_LEAVE_SUCCESS_MESSAGE);
     }
 
-    public void chatUploadImages(Long roomId, StudentInfo studentInfo, ChatImageRequest request) {
+    public void chatUploadImage(Long roomId, StudentInfo studentInfo, ChatImageRequest request) {
         String imageUrl = s3UploadService.uploadFile(CHAT_IMAGE.getDirectoryName(), request.image());
         ChatMessage chatMessage = ChatMessage.builder()
                 .type(MessageType.IMAGE)

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -87,9 +87,7 @@ public class ChatService {
     public void handleAction(WebSocketSession session, ChatMessage chatMessage) throws IllegalArgumentException {
         Chatroom chatRoom = chatRoomRepository.findById(chatMessage.getRoomId())
                 .orElseThrow(() -> new IllegalArgumentException(ERROR_CHATROOM_NOT_FOUND));
-        if (chatMessage.getType().equals(MessageType.ENTER)) {
-            sessionsPerRoom.computeIfAbsent(chatRoom.getId(), k -> new HashSet<>()).add(session);
-        } else if (chatMessage.getType().equals(MessageType.TALK)) {
+        if (chatMessage.getType().equals(MessageType.TALK)) {
             saveMessageAndHandleUnreadCount(chatMessage);
             sendMessageToRoom(chatRoom.getId(), chatMessage);
         }
@@ -216,5 +214,9 @@ public class ChatService {
         sendMessageToRoom(roomId, chatMessage);
     }
 
+    public void addSessionToRoom(Long roomId, WebSocketSession session) {
+        sessionsPerRoom.computeIfAbsent(roomId, k -> new HashSet<>()).add(session);
+        log.info("Room ID {}에 새로운 세션 추가. 현재 세션 수: {}", roomId, sessionsPerRoom.get(roomId).size());
+    }
 }
 

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -206,16 +206,12 @@ public class ChatService {
     }
 
     public void chatUploadImages(Long roomId, StudentInfo studentInfo, ChatImageRequest request) {
-        List<String> imageUrls = request.images()
-                .stream()
-                .map(image -> s3UploadService.uploadFile(CHAT_IMAGE.getDirectoryName(), image))
-                .collect(Collectors.toList());
-        String imageMessages = String.join(",", imageUrls);
+        String imageUrl = s3UploadService.uploadFile(CHAT_IMAGE.getDirectoryName(), request.image());
         ChatMessage chatMessage = ChatMessage.builder()
                 .type(MessageType.IMAGE)
                 .roomId(roomId)
                 .tempId(request.tempId())
-                .message(imageMessages)
+                .message(imageUrl)
                 .userId(studentInfo.id())
                 .time(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/team/buddyya/common/domain/S3DirectoryName.java
+++ b/src/main/java/com/team/buddyya/common/domain/S3DirectoryName.java
@@ -3,7 +3,8 @@ package com.team.buddyya.common.domain;
 public enum S3DirectoryName {
 
     STUDENT_ID_CARD("/student-id-card"),
-    FEED_IMAGE("/feeds");
+    FEED_IMAGE("/feeds"),
+    CHAT_IMAGE("/chats");
 
     private final String directoryName;
 

--- a/src/main/java/com/team/buddyya/common/service/S3UploadService.java
+++ b/src/main/java/com/team/buddyya/common/service/S3UploadService.java
@@ -45,7 +45,7 @@ public class S3UploadService {
 
     private String generateFileName(MultipartFile file) {
         String fileName = UUID.randomUUID().toString() + "-" + file.getOriginalFilename();
-        return fileName.replaceAll("\\s", "_");
+        return fileName.replaceAll("[\\s,]", "_");
     }
 
     public void deleteFile(String dir, String fileUrl) {


### PR DESCRIPTION
## 📌 관련 이슈
[채팅방 사진 전송, 채팅방 사용되지 않는 세션 종료, 수정 사항 변경](https://github.com/buddy-ya/be/issues/76)
<br><br>

## 🛠️ 작업 내용
- 채팅방 사진 전송
- 채팅방 사용되지 않은 세션 주기적으로 검사 후 종료
- 채팅방 생성 조건 변경
- 채팅방 이름을 상대방 이름으로 변경

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가?
- 예외처리가 빠진 부분은 없는가?
<br><br>

## 고민했던 점 🤔
### 채팅방에서 네트워크 오류 등 비정상적으로 종료되지 않은 세션을 서버에서 어떻게 관리할까?
1. 처음 채팅방에 들어와 session을 저장할 때 session에 timeout을  45초로 설정합니다(PING-PONG 응답은 timeout의 1.5~2배가 적당하다고 합니다)
2. 30초 주기로 `PING ` 요청을 각 session에 보내고 프론트로부터 `PONG `응답이 오면 timeout을 45초 연장합니다 
3. PONG요청을 보내주지 않아 연장하지 못한 세션은 timeout 기간이 끝나면 세션을 닫고 메모리에서 세션을 삭제합니다.

### 소켓으로 이미지를 어떻게 보낼까?
- 소켓은 실시간성에 적합하여 이미지 같은 대용량 데이터의 경우 처리 시간이 많이 소모되어 다른 메시지가 지연이 될 수 있습니다
- 따라서 http 통신으로 이미지를 s3에 저장하고 s3에서 반환한 이미지 url을 해당 채팅방에 소켓을 통해 실시간으로 처리를 하였습니다.

+ 지금 log가 많은데 프론트와 테스트 후 지워서 재배포 하겠습니다!
## 📎 커밋 범위 링크

<br><br>
