### PR TITLE
학생 인증 알림의 data에 인증 성공 여부 추가

### DIFF
--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -103,6 +103,7 @@ public class NotificationService {
             String token = getTokenByUserId(student.getId());
             Map<String, Object> data = new HashMap<>();
             data.put("type", "AUTHORIZATION");
+            data.put("isCertificated", isSuccess);
             boolean isKorean = student.getIsKorean();
             RequestNotification notification = createAuthorizationNotification(isKorean, isSuccess, token, data);
             sendToExpo(notification);


### PR DESCRIPTION
## 📌 관련 이슈
[학생 인증 알림의 data에 인증 성공 여부 추가](https://github.com/buddy-ya/be/issues/98)[#98]

<br><br>

## 🛠️ 작업 내용
- 학생 인증 알림의 data에 인증 성공 여부(isCertificated) 추가

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
