### PR TITLE
feat: 채팅 요청 수락하기 api 및 피드 차단 반영

### DIFF
--- a/src/main/java/com/team/buddyya/chatting/controller/ChatRequestController.java
+++ b/src/main/java/com/team/buddyya/chatting/controller/ChatRequestController.java
@@ -1,9 +1,12 @@
 package com.team.buddyya.chatting.controller;
 
 import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.chatting.dto.request.CreateChatroomRequest;
 import com.team.buddyya.chatting.dto.response.ChatRequestInfoResponse;
 import com.team.buddyya.chatting.dto.response.ChatRequestResponse;
+import com.team.buddyya.chatting.dto.response.CreateChatroomResponse;
 import com.team.buddyya.chatting.service.ChatRequestService;
+import com.team.buddyya.chatting.service.ChatService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +15,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRequestController {
 
     private final ChatRequestService chatRequestService;
+    private final ChatService chatService;
 
     @GetMapping("/{receiverId}")
     public ResponseEntity<ChatRequestInfoResponse> getChatRequestInfo(
@@ -40,6 +45,13 @@ public class ChatRequestController {
             , @PathVariable("receiverId") Long receiverId) {
         chatRequestService.createChatRequest(userDetails, receiverId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping
+    public ResponseEntity<CreateChatroomResponse> createOrGetChatRoom(@RequestBody CreateChatroomRequest request,
+                                                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
+        CreateChatroomResponse response = chatService.createOrGetChatRoom(request, userDetails.getStudentInfo());
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{chatRequestId}")

--- a/src/main/java/com/team/buddyya/chatting/controller/ChatRequestController.java
+++ b/src/main/java/com/team/buddyya/chatting/controller/ChatRequestController.java
@@ -51,6 +51,7 @@ public class ChatRequestController {
     public ResponseEntity<CreateChatroomResponse> createOrGetChatRoom(@RequestBody CreateChatroomRequest request,
                                                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
         CreateChatroomResponse response = chatService.createOrGetChatRoom(request, userDetails.getStudentInfo());
+        chatRequestService.deleteChatRequest(userDetails, request.chatRequestId());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/team/buddyya/chatting/dto/request/CreateChatroomRequest.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/request/CreateChatroomRequest.java
@@ -1,6 +1,7 @@
 package com.team.buddyya.chatting.dto.request;
 
 public record CreateChatroomRequest(
-        Long buddyId
+        Long buddyId,
+        Long chatRequestId
 ) {
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/response/ChatRequestResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/ChatRequestResponse.java
@@ -1,5 +1,7 @@
 package com.team.buddyya.chatting.dto.response;
 
+import static com.team.buddyya.student.domain.UserProfileDefaultImage.getChatroomProfileImage;
+
 import com.team.buddyya.chatting.domain.ChatRequest;
 import java.time.LocalDateTime;
 
@@ -20,7 +22,7 @@ public record ChatRequestResponse(
                 chatRequest.getSender().getUniversity().getUniversityName(),
                 chatRequest.getSender().getName(),
                 chatRequest.getSender().getCountry(),
-                chatRequest.getSender().getProfileImage().getUrl(),
+                getChatroomProfileImage(chatRequest.getSender()),
                 chatRequest.getCreatedDate()
         );
     }

--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
@@ -2,9 +2,12 @@ package com.team.buddyya.feed.dto.response.comment;
 
 import com.team.buddyya.feed.domain.Comment;
 import com.team.buddyya.feed.repository.CommentLikeRepository;
+import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.domain.UserProfileDefaultImage;
+import com.team.buddyya.student.repository.BlockRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 public record CommentResponse(
         Long id,
@@ -20,18 +23,20 @@ public record CommentResponse(
         boolean isLiked,
         boolean isFeedOwner,
         boolean isCommentOwner,
+        boolean isBlocked,
         boolean isProfileImageUpload,
         List<CommentResponse> replies
 ) {
 
     public static CommentResponse from(Comment comment, Long feedOwnerId, Long currentUserId,
-                                       CommentLikeRepository commentLikeRepository) {
+                                       CommentLikeRepository commentLikeRepository, Set<Long> blockedStudentIds) {
         boolean isFeedOwner = feedOwnerId.equals(comment.getStudent().getId());
         boolean isCommentOwner = currentUserId.equals(comment.getStudent().getId());
         boolean isProfileImageUpload = UserProfileDefaultImage.isProfileImageUpload(comment.getStudent());
         boolean isLiked = commentLikeRepository.existsByCommentAndStudentId(comment, currentUserId);
+        boolean isBlocked = blockedStudentIds.contains(comment.getStudent().getId());
         List<CommentResponse> replies = comment.getChildren().stream()
-                .map(reply -> CommentResponse.from(reply, feedOwnerId, currentUserId, commentLikeRepository))
+                .map(reply -> CommentResponse.from(reply, feedOwnerId, currentUserId, commentLikeRepository, blockedStudentIds))
                 .toList();
         return new CommentResponse(
                 comment.getId(),
@@ -47,6 +52,7 @@ public record CommentResponse(
                 isLiked,
                 isFeedOwner,
                 isCommentOwner,
+                isBlocked,
                 isProfileImageUpload,
                 replies
         );

--- a/src/main/java/com/team/buddyya/student/repository/BlockRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/BlockRepository.java
@@ -2,7 +2,6 @@ package com.team.buddyya.student.repository;
 
 import com.team.buddyya.student.domain.Block;
 import com.team.buddyya.student.domain.Student;
-import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/team/buddyya/student/repository/BlockRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/BlockRepository.java
@@ -2,9 +2,17 @@ package com.team.buddyya.student.repository;
 
 import com.team.buddyya.student.domain.Block;
 import com.team.buddyya.student.domain.Student;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
 
     boolean existsByBlockerAndBlockedStudentId(Student blocker, Long blockedStudentId);
+
+    @Query("select b.blockedStudentId from Block b where b.blocker.id = :blockerId")
+    Set<Long> findBlockedStudentIdByBlockerId(@Param("blockerId") Long blockerId);
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
- [채팅 요청 수락하기 #123](https://github.com/buddy-ya/be/issues/123)
- [피드 변경사항 반영 #55](https://github.com/buddy-ya/be/issues/55)

## 🛠️ 작업 내용
- **채팅 요청 목록 조회 개선:**  
  기존의 채팅방 생성 API를 채팅 요청 수락하기 API로 대체하였습니다. 이는 채팅방 생성의 확장성을 고려한 변경으로, 피드 및 매칭 상황에서 각각 다른 정보를 전달할 수 있도록 분리하였습니다.
  
- **피드 및 댓글 조회 로직 변경:**  
  피드 조회 시 차단한 유저의 피드를 제외하도록 로직을 반영하였습니다.  
  또한, 부모 댓글은 조회 대상에서 제외하고, 대댓글의 경우 `isBlocked` 필드를 추가하여 클라이언트가 "차단된 유저의 댓글입니다"와 같이 렌더링할 수 있도록 설계하였습니다.

세부 작업 내용은 아래와 같습니다:
- **채팅방 생성 API 변경:**  
  채팅이 필요한 경우 호출되던 기존 채팅방 생성 API를 대체하고, 피드와 매칭 등에서 별도의 API를 통해 채팅방 생성 Service 함수를 호출하도록 구현하였습니다.
  
- **채팅 요청 수락 처리:**  
  채팅 요청을 수락하면 해당 요청이 채팅 요청 목록에서 제거되도록 하였습니다.
  
- **프로필 사진 반환 수정:**  
  채팅 요청 목록 조회 시, 각 요청에 대해 정확한 프로필 사진이 반환되도록 개선하였습니다.

## 🎯 리뷰 포인트
- **`BlockRepository`에서 `JPQL` 사용 이유:**  
  현재 `Student`와 `Block`은 일대다 관계로, 양방향 매핑이 되어 있지 않습니다.  
  A 유저가 차단한 사용자들을 조회하기 위해서는 다음과 같은 과정을 거치게 됩니다:
  1. `BlockRepository`에서 A 유저가 `blocker`로 설정된 모든 `Block` 엔티티를 조회.
  2. 각 `Block` 엔티티에서 `blockedStudentId` 값을 추출하기 위해 반복문을 사용.
  3. 추출된 ID들을 `Set`으로 매핑하기 위해 추가 반복문을 수행.
  => `Set`을 이용한 이유는 `contains` 작업을 `O(1)`로 줄이기 위함입니다.
  
  이러한 다단계 로직을 단일 `JPQL` 쿼리로 처리하여 blockedStudentId만 반환받도록 개선하였습니다.  
  다만, 팀 내 컨벤션 상 `JPQL` 사용은 이후 리팩터링 단계에서 재검토하기로 하였으므로, 
  `JPQL 없이 A 유저가 차단한 사용자들을 간편하게 조회할 수 있는 다른 방안이 있다면 의견 남겨주시면 좋겠습니다.`

- **`RequestBody`에서 필드 누락 허용:**  
  기존 채팅방 생성 API의 body에 단순히 `chatRequestId` 필드만 추가하는 방식으로도 충분할 수 있으나, 매칭 등 다양한 상황에서 채팅방 생성 API가 호출될 수 있으므로, body 구조의 유연성이 필요했습니다.  
이 과정에서 `RequestBody`에서 필드 누락을 허용하는 방식에 대해 고민하였습니다. 
즉 매칭일때는 `chatRequestId`필드를 누락한다면, 하나의 api로도 가능하지만, 이게 좋은 방식인가 싶어 따로 분리하게 되었습니다.
`RequestBody에서 필드 누락을 허용하는 것이 유연한 구조인가?, 즉 그렇게 사용해도 되는걸까?`
이 부분에 대해 여러분의 의견을 공유해주시면 감사하겠습니다.

## 📎 커밋 범위 링크
