### PR TITLE
feat: 읽지 않은 총 메시지 개수 표시

### DIFF
--- a/src/main/java/com/team/buddyya/chatting/controller/ChatController.java
+++ b/src/main/java/com/team/buddyya/chatting/controller/ChatController.java
@@ -12,8 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 import static org.springframework.data.domain.Sort.Direction;
 
 @RestController
@@ -33,7 +31,7 @@ public class ChatController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ChatroomResponse>> getChatRooms(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ChatroomListResponse> getChatRooms(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(chatService.getChatRooms(userDetails.getStudentInfo()));
     }
 

--- a/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomListResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomListResponse.java
@@ -1,0 +1,13 @@
+package com.team.buddyya.chatting.dto.response;
+
+import java.util.List;
+
+public record ChatroomListResponse(
+        List<ChatroomResponse> rooms,
+        int totalUnreadCount
+) {
+
+    public static ChatroomListResponse from(List<ChatroomResponse> chatroomResponse, int totalUnreadCount) {
+        return new ChatroomListResponse(chatroomResponse, totalUnreadCount);
+    }
+}

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -156,14 +156,18 @@ public class ChatService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatroomResponse> getChatRooms(StudentInfo studentInfo) {
+    public ChatroomListResponse getChatRooms(StudentInfo studentInfo) {
         Student student = findStudentService.findByStudentId(studentInfo.id());
-        return student.getChatroomStudents().stream()
+        List<ChatroomResponse> chatroomResponses = student.getChatroomStudents().stream()
                 .filter(chatroomStudent -> !chatroomStudent.getIsExited())
                 .map(chatroomStudent -> createChatroomResponse(chatroomStudent))
                 .filter(Objects::nonNull)
                 .sorted((a, b) -> b.lastMessageDate().compareTo(a.lastMessageDate()))
                 .collect(Collectors.toList());
+        int totalUnreadCount = chatroomResponses.stream()
+                .mapToInt(ChatroomResponse::unreadCount)
+                .sum();
+        return ChatroomListResponse.from(chatroomResponses, totalUnreadCount);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/db/migration/V2__Add_student_column_is_deleted.sql
+++ b/src/main/resources/db/migration/V2__Add_student_column_is_deleted.sql
@@ -1,0 +1,2 @@
+ALTER TABLE student
+    ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## 📌 관련 이슈
[읽지 않은 총 메시지 개수 표시 [#131]](https://github.com/buddy-ya/be/issues/131)
<br><br>

## 🛠️ 작업 내용
- 읽지 않은 총 메시지 개수 표시하는 기능을 추가하였습니다
- 기존 채팅 목록을 반환하는 api에서 totalUnreadCount를 추가하였습니다
- student의 is_deleted 필드를 flyway를 통해 DB에도 반영하였습니다.
<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가?

### 고민한 부분
총 읽지 않은 메시지를 구현하기 위한 방법은 다음과 같습니다.
1. **totalUnreadCount 필드 추가 (한 번에 관리)**
2. **채팅방별 unreadCount 합산 API 사용**

1번의 경우 단일 필드로 관리가 가능하다는 장점이 있지만 채팅을 보낼 때마다, `채팅방에 들어갈 때마다 개수를 동기화` 시켜줘야 한다는 번거로움이 있습니다.

2번의 경우 이미 동기화가 되어 있는 각 채팅방의 unreadCount를 더하기만 하면 되지만, 표시할 때마다 `모든 채팅방의 unreadCount를 합산`해야 한다는 번거로움이 있습니다.

이 `두 방법 모두 비효율적`이라 생각하여 `채팅 목록을 조회할 때만 개수가 동기화`가 되도록 수정하였습니다.

기존 채팅 목록을 반환할 때 unreadCount를 가져오며, totalUnreadCount는 가져온 `채팅 목록에서 합산만 하여 별도의 쿼리 없이 읽지 않은 총 메시지를 표시해주는 방식으로 구현`하였습니다.

<br><br>


## 📎 커밋 범위 링크
https://github.com/buddy-ya/be/pull/132/files/27e01c4ae347fc6b42c96821fc11bdef257a0121
<br><br>
