### PR TITLE
refactor: 사용자 정보 동기화를 위한 DTO에 프로필사진 등록 여부 추가

### DIFF
--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -17,8 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -58,9 +56,8 @@ public class PhoneAuthenticationService {
             String accessToken = jwtUtils.createAccessToken(new TokenInfoRequest(student.getId()));
             String refreshToken = student.getAuthToken().getRefreshToken();
             boolean isStudentIdCardRequested = studentIdCardRepository.findByStudent(student).isPresent();
-            boolean isDefaultProfileImage = isDefaultUserProfileImage(student);
-            return UserResponse.from(student, isStudentIdCardRequested, "EXISTING_MEMBER", accessToken, refreshToken, isDefaultProfileImage);
+            return UserResponse.from(student, isStudentIdCardRequested, EXISTING_MEMBER, accessToken, refreshToken);
         }
-        return UserResponse.from("NEW_MEMBER");
+        return UserResponse.from(NEW_MEMBER);
     }
 }

--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -51,15 +53,14 @@ public class PhoneAuthenticationService {
 
     public UserResponse checkMembership(String phoneNumber) {
         Optional<Student> optionalStudent = studentRepository.findByPhoneNumber(phoneNumber);
-
         if (optionalStudent.isPresent()) {
             Student student = optionalStudent.get();
             String accessToken = jwtUtils.createAccessToken(new TokenInfoRequest(student.getId()));
             String refreshToken = student.getAuthToken().getRefreshToken();
             boolean isStudentIdCardRequested = studentIdCardRepository.findByStudent(student).isPresent();
-            return UserResponse.from(student, isStudentIdCardRequested, "EXISTING_MEMBER", accessToken, refreshToken);
+            boolean isDefaultProfileImage = isDefaultUserProfileImage(student);
+            return UserResponse.from(student, isStudentIdCardRequested, "EXISTING_MEMBER", accessToken, refreshToken, isDefaultProfileImage);
         }
-
         return UserResponse.from("NEW_MEMBER");
     }
 }

--- a/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
@@ -15,6 +15,7 @@ public record UserResponse(
         Boolean isCertificated,
         Boolean isStudentIdCardRequested,
         Boolean isKorean,
+        Boolean isDefaultProfileImage,
         List<String> majors,
         List<String> languages,
         List<String> interests,
@@ -23,7 +24,7 @@ public record UserResponse(
         String refreshToken
 ) {
 
-    public static UserResponse from(Student student, boolean isStudentIdCardRequested) {
+    public static UserResponse from(Student student, boolean isStudentIdCardRequested, Boolean isDefaultProfileImage) {
         return new UserResponse(
                 student.getId(),
                 student.getName(),
@@ -34,6 +35,7 @@ public record UserResponse(
                 student.getIsCertificated(),
                 isStudentIdCardRequested,
                 student.getIsKorean(),
+                isDefaultProfileImage,
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
@@ -43,7 +45,7 @@ public record UserResponse(
         );
     }
 
-    public static UserResponse from(Student student) {
+    public static UserResponse from(Student student, Boolean isDefaultProfileImage) {
         return new UserResponse(
                 student.getId(),
                 student.getName(),
@@ -54,6 +56,7 @@ public record UserResponse(
                 null,
                 null,
                 null,
+                isDefaultProfileImage,
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
@@ -63,7 +66,7 @@ public record UserResponse(
         );
     }
 
-    public static UserResponse from(Student student, Boolean isStudentIdCardRequested, String accessToken, String refreshToken) {
+    public static UserResponse from(Student student, Boolean isStudentIdCardRequested, String accessToken, String refreshToken, Boolean isDefaultProfileImage) {
         return new UserResponse(
                 student.getId(),
                 student.getName(),
@@ -74,6 +77,7 @@ public record UserResponse(
                 student.getIsCertificated(),
                 isStudentIdCardRequested,
                 student.getIsKorean(),
+                isDefaultProfileImage,
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
@@ -83,7 +87,7 @@ public record UserResponse(
         );
     }
 
-    public static UserResponse from(Student student, Boolean isStudentIdCardRequested, String status, String accessToken, String refreshToken) {
+    public static UserResponse from(Student student, Boolean isStudentIdCardRequested, String status, String accessToken, String refreshToken, Boolean isDefaultProfileImage) {
         return new UserResponse(
                 student.getId(),
                 student.getName(),
@@ -94,6 +98,7 @@ public record UserResponse(
                 student.getIsCertificated(),
                 isStudentIdCardRequested,
                 student.getIsKorean(),
+                isDefaultProfileImage,
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
@@ -114,6 +119,7 @@ public record UserResponse(
                 false,
                 false,
                 null,
+                true,
                 null,
                 null,
                 null,

--- a/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
@@ -5,6 +5,8 @@ import com.team.buddyya.student.domain.Student;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
+
 public record UserResponse(
         Long id,
         String name,
@@ -24,7 +26,7 @@ public record UserResponse(
         String refreshToken
 ) {
 
-    public static UserResponse from(Student student, boolean isStudentIdCardRequested, Boolean isDefaultProfileImage) {
+    public static UserResponse from(Student student, boolean isStudentIdCardRequested) {
         return new UserResponse(
                 student.getId(),
                 student.getName(),
@@ -35,7 +37,7 @@ public record UserResponse(
                 student.getIsCertificated(),
                 isStudentIdCardRequested,
                 student.getIsKorean(),
-                isDefaultProfileImage,
+                isDefaultUserProfileImage(student),
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
@@ -45,7 +47,7 @@ public record UserResponse(
         );
     }
 
-    public static UserResponse from(Student student, Boolean isDefaultProfileImage) {
+    public static UserResponse from(Student student) {
         return new UserResponse(
                 student.getId(),
                 student.getName(),
@@ -56,7 +58,7 @@ public record UserResponse(
                 null,
                 null,
                 null,
-                isDefaultProfileImage,
+                isDefaultUserProfileImage(student),
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
@@ -66,7 +68,7 @@ public record UserResponse(
         );
     }
 
-    public static UserResponse from(Student student, Boolean isStudentIdCardRequested, String accessToken, String refreshToken, Boolean isDefaultProfileImage) {
+    public static UserResponse from(Student student, Boolean isStudentIdCardRequested, String accessToken, String refreshToken) {
         return new UserResponse(
                 student.getId(),
                 student.getName(),
@@ -77,7 +79,7 @@ public record UserResponse(
                 student.getIsCertificated(),
                 isStudentIdCardRequested,
                 student.getIsKorean(),
-                isDefaultProfileImage,
+                isDefaultUserProfileImage(student),
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
@@ -87,7 +89,7 @@ public record UserResponse(
         );
     }
 
-    public static UserResponse from(Student student, Boolean isStudentIdCardRequested, String status, String accessToken, String refreshToken, Boolean isDefaultProfileImage) {
+    public static UserResponse from(Student student, Boolean isStudentIdCardRequested, String status, String accessToken, String refreshToken) {
         return new UserResponse(
                 student.getId(),
                 student.getName(),
@@ -98,7 +100,7 @@ public record UserResponse(
                 student.getIsCertificated(),
                 isStudentIdCardRequested,
                 student.getIsKorean(),
-                isDefaultProfileImage,
+                isDefaultUserProfileImage(student),
                 convertToStringList(student.getMajors()),
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),

--- a/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
+++ b/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
@@ -36,8 +36,7 @@ public class OnBoardingService {
         studentMajorService.createStudentMajors(request.majors(), student);
         studentInterestService.createStudentInterests(request.interests(), student);
         studentLanguageService.createStudentLanguages(request.languages(), student);
-        boolean isDefaultProfileImage = isDefaultUserProfileImage(student);
-        return UserResponse.from(student, false, accessToken, refreshToken, isDefaultProfileImage);
+        return UserResponse.from(student, false, accessToken, refreshToken);
     }
 
     private String createAndSaveToken(Student student) {

--- a/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
+++ b/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
-
 @Service
 @RequiredArgsConstructor
 @Transactional

--- a/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
+++ b/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -34,7 +36,8 @@ public class OnBoardingService {
         studentMajorService.createStudentMajors(request.majors(), student);
         studentInterestService.createStudentInterests(request.interests(), student);
         studentLanguageService.createStudentLanguages(request.languages(), student);
-        return UserResponse.from(student,false,accessToken, refreshToken);
+        boolean isDefaultProfileImage = isDefaultUserProfileImage(student);
+        return UserResponse.from(student,false,accessToken, refreshToken, isDefaultProfileImage);
     }
 
     private String createAndSaveToken(Student student) {

--- a/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
+++ b/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
@@ -37,7 +37,7 @@ public class OnBoardingService {
         studentInterestService.createStudentInterests(request.interests(), student);
         studentLanguageService.createStudentLanguages(request.languages(), student);
         boolean isDefaultProfileImage = isDefaultUserProfileImage(student);
-        return UserResponse.from(student,false,accessToken, refreshToken, isDefaultProfileImage);
+        return UserResponse.from(student, false, accessToken, refreshToken, isDefaultProfileImage);
     }
 
     private String createAndSaveToken(Student student) {

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -90,10 +90,9 @@ public class StudentService {
             default:
                 throw new StudentException(StudentExceptionType.UNSUPPORTED_UPDATE_KEY);
         }
-        boolean isDefaultProfileImage = isDefaultUserProfileImage(student);
         boolean isStudentIdCardRequested = studentIdCardRepository.findByStudent(student)
                 .isPresent();
-        return UserResponse.from(student, isStudentIdCardRequested, isDefaultProfileImage);
+        return UserResponse.from(student, isStudentIdCardRequested);
     }
 
     public UserResponse updateUserProfileImage(StudentInfo studentInfo, boolean isDefault, UpdateProfileImageRequest request) {
@@ -102,23 +101,22 @@ public class StudentService {
                 .isPresent();
         if (isDefault) {
             profileImageService.updateUserProfileImage(student, USER_PROFILE_DEFAULT_IMAGE.getUrl());
-            return UserResponse.from(student, isStudentIdCardRequested,true);
+            return UserResponse.from(student, isStudentIdCardRequested);
         }
         String imageUrl = s3UploadService.uploadFile(PROFILE_IMAGE.getDirectoryName(), request.profileImage());
         profileImageService.updateUserProfileImage(student, imageUrl);
-        return UserResponse.from(student, isStudentIdCardRequested, false);
+        return UserResponse.from(student, isStudentIdCardRequested);
     }
 
     @Transactional(readOnly = true)
     public UserResponse getUserInfo(StudentInfo studentInfo, Long userId) {
         Student student = findStudentService.findByStudentId(userId);
-        boolean isDefaultProfileImage = isDefaultUserProfileImage(student);
         if (studentInfo.id() != userId) {
-            return UserResponse.from(student, isDefaultProfileImage);
+            return UserResponse.from(student);
         }
         boolean isStudentIdCardRequested = studentIdCardRepository.findByStudent(student)
                 .isPresent();
-        return UserResponse.from(student, isStudentIdCardRequested, isDefaultProfileImage);
+        return UserResponse.from(student, isStudentIdCardRequested);
     }
 
     public void updateStudentCertification(Student student) {

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static com.team.buddyya.common.domain.S3DirectoryName.PROFILE_IMAGE;
 import static com.team.buddyya.student.domain.UserProfileDefaultImage.USER_PROFILE_DEFAULT_IMAGE;
-import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 📌 관련 이슈
[사용자 정보 동기화를 위한 DTO에 프로필사진 등록 여부 추가](https://github.com/buddy-ya/be/issues/133)[#133]

<br><br>

## 🛠️ 작업 내용

### 사용자 정보 동기화를 위한 DTO에 프로필사진 등록 여부 추가

### 추가된 부분

- 회원가입
onboardingservice
-> onboard

- 유저 정보 변경
StudentService 
-> updateUser
-> getUserInfo
-> updateUserProfileImage

- 핸드폰 인증 시 기존회원 vs 신규 회원
PhoneAuthenticationService
->checkMembership


## 🎯 리뷰 포인트

- 코드 컨벤션에 어긋난 부분은 없나요?
- 등록되어야할 부분이 빠진 부분은 없나요?

<br><br>

## 📎 커밋 범위 링크

<br><br>
