### PR TITLE
feat: 신고 시 저장 내용 수정 & 관리자 신고 조회

### DIFF
--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -1,7 +1,7 @@
 package com.team.buddyya.admin.controller;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
-import com.team.buddyya.admin.dto.response.AdminReportsResponse;
+import com.team.buddyya.admin.dto.response.AdminReportResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.admin.service.AdminService;
@@ -29,7 +29,7 @@ public class AdminController {
     }
 
     @GetMapping("/reports")
-    public ResponseEntity<List<AdminReportsResponse>> getReports() {
+    public ResponseEntity<List<AdminReportResponse>> getReports() {
         return ResponseEntity.ok(adminService.getAllReports());
     }
 }

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -1,12 +1,15 @@
 package com.team.buddyya.admin.controller;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
+import com.team.buddyya.admin.dto.response.AdminReportsResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +26,10 @@ public class AdminController {
     @PostMapping("/student-id-cards/verify")
     public ResponseEntity<StudentVerificationResponse> verifyStudentIdCard(@RequestBody StudentVerificationRequest request) {
         return ResponseEntity.ok(adminService.verifyStudentIdCard(request));
+    }
+
+    @GetMapping("/reports")
+    public ResponseEntity<List<AdminReportsResponse>> getReports() {
+        return ResponseEntity.ok(adminService.getAllReports());
     }
 }

--- a/src/main/java/com/team/buddyya/admin/dto/response/AdminReportResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/AdminReportResponse.java
@@ -16,6 +16,7 @@ public record AdminReportResponse(
         String reason,
         List<String> imageUrls
 ) {
+
     public static AdminReportResponse from(Report report, List<String> imageUrls) {
         return new AdminReportResponse(
                 report.getId(),

--- a/src/main/java/com/team/buddyya/admin/dto/response/AdminReportResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/AdminReportResponse.java
@@ -20,14 +20,28 @@ public record AdminReportResponse(
         return new AdminReportResponse(
                 report.getId(),
                 report.getType(),
-                report.getType() == ReportType.CHATROOM ? report.getReportedId() : null,
+                getReportedId(report),
                 report.getReportUserId(),
                 report.getReportedUserId(),
-                report.getType() == ReportType.FEED ? report.getTitle() : null,
+                getTitle(report),
                 getContent(report),
                 report.getReason(),
                 imageUrls
         );
+    }
+
+    private static Long getReportedId(Report report) {
+        if (report.getType() == ReportType.CHATROOM) {
+            return report.getReportedId();
+        }
+        return null;
+    }
+
+    private static String getTitle(Report report) {
+        if (report.getType() == ReportType.FEED) {
+            return report.getTitle();
+        }
+        return null;
     }
 
     private static String getContent(Report report) {

--- a/src/main/java/com/team/buddyya/admin/dto/response/AdminReportResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/AdminReportResponse.java
@@ -5,7 +5,7 @@ import com.team.buddyya.report.domain.ReportType;
 
 import java.util.List;
 
-public record AdminReportsResponse(
+public record AdminReportResponse(
         Long id,
         ReportType type,
         Long reportedId,
@@ -16,8 +16,8 @@ public record AdminReportsResponse(
         String reason,
         List<String> imageUrls
 ) {
-    public static AdminReportsResponse from(Report report, List<String> imageUrls) {
-        return new AdminReportsResponse(
+    public static AdminReportResponse from(Report report, List<String> imageUrls) {
+        return new AdminReportResponse(
                 report.getId(),
                 report.getType(),
                 report.getType() == ReportType.CHATROOM ? report.getReportedId() : null,

--- a/src/main/java/com/team/buddyya/admin/dto/response/AdminReportsResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/AdminReportsResponse.java
@@ -1,0 +1,50 @@
+package com.team.buddyya.admin.dto.response;
+
+import com.team.buddyya.report.domain.Report;
+import com.team.buddyya.report.domain.ReportType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record AdminReportsResponse(
+        Long id,
+        ReportType type,
+        Long reportedId,
+        Long reportUserId,
+        Long reportedUserId,
+        String title,
+        String content,
+        String reason,
+        List<String> imageUrls
+) {
+    public static AdminReportsResponse from(Report report) {
+        return new AdminReportsResponse(
+                report.getId(),
+                report.getType(),
+                report.getType() == ReportType.CHATROOM ? report.getReportedId() : null,
+                report.getReportUserId(),
+                report.getReportedUserId(),
+                report.getType() == ReportType.FEED ? report.getTitle() : null,
+                getContent(report),
+                report.getReason(),
+                getImageUrls(report)
+        );
+    }
+
+    private static String getContent(Report report) {
+        return switch (report.getType()) {
+            case FEED, COMMENT -> report.getContent();
+            default -> null;
+        };
+    }
+
+    private static List<String> getImageUrls(Report report) {
+        if (report.getImages() == null || report.getImages().isEmpty()) {
+            return null;
+        }
+        return report.getImages().stream()
+                .map(image -> image.getImageUrl())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/team/buddyya/admin/dto/response/AdminReportsResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/AdminReportsResponse.java
@@ -4,7 +4,6 @@ import com.team.buddyya.report.domain.Report;
 import com.team.buddyya.report.domain.ReportType;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record AdminReportsResponse(
         Long id,
@@ -17,7 +16,7 @@ public record AdminReportsResponse(
         String reason,
         List<String> imageUrls
 ) {
-    public static AdminReportsResponse from(Report report) {
+    public static AdminReportsResponse from(Report report, List<String> imageUrls) {
         return new AdminReportsResponse(
                 report.getId(),
                 report.getType(),
@@ -27,7 +26,7 @@ public record AdminReportsResponse(
                 report.getType() == ReportType.FEED ? report.getTitle() : null,
                 getContent(report),
                 report.getReason(),
-                getImageUrls(report)
+                imageUrls
         );
     }
 
@@ -37,14 +36,4 @@ public record AdminReportsResponse(
             default -> null;
         };
     }
-
-    private static List<String> getImageUrls(Report report) {
-        if (report.getImages() == null || report.getImages().isEmpty()) {
-            return null;
-        }
-        return report.getImages().stream()
-                .map(image -> image.getImageUrl())
-                .collect(Collectors.toList());
-    }
-
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -8,6 +8,8 @@ import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.notification.service.NotificationService;
+import com.team.buddyya.report.domain.ReportImage;
+import com.team.buddyya.report.repository.ReportImageRepository;
 import com.team.buddyya.report.repository.ReportRepository;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
@@ -36,6 +38,7 @@ public class AdminService {
     private final NotificationService notificationService;
     private final StudentIdCardRepository studentIdCardRepository;
     private final ReportRepository reportRepository;
+    private final ReportImageRepository reportImageRepository;
 
     @Transactional(readOnly = true)
     public StudentIdCardListResponse getStudentIdCards() {
@@ -56,7 +59,13 @@ public class AdminService {
 
     public List<AdminReportsResponse> getAllReports() {
         return reportRepository.findAll().stream()
-                .map(AdminReportsResponse::from)
+                .map(report -> AdminReportsResponse.from(report, getImageUrlsByReportId(report.getId())))
+                .collect(Collectors.toList());
+    }
+
+    private List<String> getImageUrlsByReportId(Long reportId) {
+        return reportImageRepository.findByReportId(reportId).stream()
+                .map(ReportImage::getImageUrl)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -1,12 +1,14 @@
 package com.team.buddyya.admin.service;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
+import com.team.buddyya.admin.dto.response.AdminReportsResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.notification.service.NotificationService;
+import com.team.buddyya.report.repository.ReportRepository;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
 import com.team.buddyya.student.service.StudentService;
@@ -30,9 +32,10 @@ public class AdminService {
 
     private final StudentService studentService;
     private final FindStudentService findStudentService;
-    private final StudentIdCardRepository studentIdCardRepository;
     private final S3UploadService s3UploadService;
     private final NotificationService notificationService;
+    private final StudentIdCardRepository studentIdCardRepository;
+    private final ReportRepository reportRepository;
 
     @Transactional(readOnly = true)
     public StudentIdCardListResponse getStudentIdCards() {
@@ -49,5 +52,11 @@ public class AdminService {
         studentService.updateStudentCertification(student);
         notificationService.sendAuthorizationNotification(student, true);
         return new StudentVerificationResponse(VERIFICATION_COMPLETED_MESSAGE);
+    }
+
+    public List<AdminReportsResponse> getAllReports() {
+        return reportRepository.findAll().stream()
+                .map(AdminReportsResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -1,7 +1,7 @@
 package com.team.buddyya.admin.service;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
-import com.team.buddyya.admin.dto.response.AdminReportsResponse;
+import com.team.buddyya.admin.dto.response.AdminReportResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
@@ -57,9 +57,9 @@ public class AdminService {
         return new StudentVerificationResponse(VERIFICATION_COMPLETED_MESSAGE);
     }
 
-    public List<AdminReportsResponse> getAllReports() {
+    public List<AdminReportResponse> getAllReports() {
         return reportRepository.findAll().stream()
-                .map(report -> AdminReportsResponse.from(report, getImageUrlsByReportId(report.getId())))
+                .map(report -> AdminReportResponse.from(report, getImageUrlsByReportId(report.getId())))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -87,6 +87,12 @@ public class ChatService {
         return newChatroom;
     }
 
+    @Transactional(readOnly = true)
+    public Chatroom findByChatroomByChatroomId(Long chatroomId) {
+        return chatRoomRepository.findById(chatroomId)
+                .orElseThrow(() -> new ChatException(ChatExceptionType.CHATROOM_NOT_FOUND));
+    }
+
     public void handleAction(ChatMessage chatMessage) throws IllegalArgumentException {
         Chatroom chatRoom = chatRoomRepository.findById(chatMessage.getRoomId())
                 .orElseThrow(() -> new IllegalArgumentException(ERROR_CHATROOM_NOT_FOUND));

--- a/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
+++ b/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                                 "/auth/reissue", "/auth/test").permitAll()
                         .requestMatchers("/auth/fail", "/admin/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/users", "/auth/success", "/certification/**", "/feeds/**", "/chatrooms/**",
-                                "/report", "/chat-requests/**").hasAuthority("ROLE_STUDENT")
+                                "/report", "/chat-requests/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_STUDENT")
                         .anyRequest().authenticated()
                 );
         return http.build();

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -15,11 +15,12 @@ import com.team.buddyya.notification.service.NotificationService;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.repository.BlockRepository;
 import com.team.buddyya.student.service.FindStudentService;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
 
 @Service
 @Transactional
@@ -34,12 +35,12 @@ public class CommentService {
     private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
-    Feed findFeedByFeedId(Long feedId) {
+    public Feed findFeedByFeedId(Long feedId) {
         return feedRepository.findById(feedId).orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
-    Comment findCommentByCommentId(Long commentId) {
+    public Comment findCommentByCommentId(Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.COMMENT_NOT_FOUND));
     }
@@ -66,7 +67,7 @@ public class CommentService {
             if (parent.getParent() != null) {
                 throw new FeedException(FeedExceptionType.COMMENT_DEPTH_LIMIT);
             }
-            notificationService.sendCommentReplyNotification(feed,parent, request.content());
+            notificationService.sendCommentReplyNotification(feed, parent, request.content());
         }
         Comment comment = Comment.builder()
                 .student(student)

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -35,12 +35,12 @@ public class CommentService {
     private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
-    public Feed findFeedByFeedId(Long feedId) {
+    protected Feed findFeedByFeedId(Long feedId) {
         return feedRepository.findById(feedId).orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
-    public Comment findCommentByCommentId(Long commentId) {
+    protected Comment findCommentByCommentId(Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.COMMENT_NOT_FOUND));
     }

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -1,11 +1,7 @@
 package com.team.buddyya.feed.service;
 
 import com.team.buddyya.auth.domain.StudentInfo;
-import com.team.buddyya.feed.domain.Bookmark;
-import com.team.buddyya.feed.domain.Category;
-import com.team.buddyya.feed.domain.Feed;
-import com.team.buddyya.feed.domain.FeedImage;
-import com.team.buddyya.feed.domain.FeedUserAction;
+import com.team.buddyya.feed.domain.*;
 import com.team.buddyya.feed.dto.request.feed.FeedCreateRequest;
 import com.team.buddyya.feed.dto.request.feed.FeedListRequest;
 import com.team.buddyya.feed.dto.request.feed.FeedUpdateRequest;
@@ -19,9 +15,6 @@ import com.team.buddyya.feed.repository.FeedRepository;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.repository.BlockRepository;
 import com.team.buddyya.student.service.FindStudentService;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -30,6 +23,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Set;
 
 @Service
 @Transactional
@@ -47,13 +43,13 @@ public class FeedService {
     private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
-    Feed findFeedByFeedId(Long feedId) {
+    public Feed findFeedByFeedId(Long feedId) {
         return feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
-    Student findStudentByStudentId(Long studentId) {
+    public Student findStudentByStudentId(Long studentId) {
         return findStudentService.findByStudentId(studentId);
     }
 

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -43,13 +43,13 @@ public class FeedService {
     private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
-    public Feed findFeedByFeedId(Long feedId) {
+    protected Feed findFeedByFeedId(Long feedId) {
         return feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
-    public Student findStudentByStudentId(Long studentId) {
+    protected Student findStudentByStudentId(Long studentId) {
         return findStudentService.findByStudentId(studentId);
     }
 

--- a/src/main/java/com/team/buddyya/notification/dto/response/SaveTokenResponse.java
+++ b/src/main/java/com/team/buddyya/notification/dto/response/SaveTokenResponse.java
@@ -1,6 +1,7 @@
 package com.team.buddyya.notification.dto.response;
 
 public record SaveTokenResponse(String message) {
+
     public static SaveTokenResponse from(String message) {
         return new SaveTokenResponse(message);
     }

--- a/src/main/java/com/team/buddyya/report/domain/Report.java
+++ b/src/main/java/com/team/buddyya/report/domain/Report.java
@@ -5,6 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -22,7 +25,7 @@ public class Report {
     @Column(name = "type", nullable = false)
     private ReportType type;
 
-    @Column(name = "reported_id", nullable = false)
+    @Column(name = "reported_id")
     private Long reportedId;
 
     @Column(name = "report_user_id", nullable = false)
@@ -31,15 +34,31 @@ public class Report {
     @Column(name = "reported_user_id", nullable = false)
     private Long reportedUserId;
 
-    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
+    @Column(name = "reason", columnDefinition = "TEXT", nullable = false)
+    private String reason;
+
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReportImage> images = new ArrayList<>();
+
     @Builder
-    public Report(ReportType type, Long reportedId, Long reportUserId, Long reportedUserId, String content) {
+    public Report(ReportType type, Long reportedId, Long reportUserId, Long reportedUserId,
+                  String title, String content, String reason, List<ReportImage> images) {
         this.type = type;
         this.reportedId = reportedId;
         this.reportUserId = reportUserId;
         this.reportedUserId = reportedUserId;
+        this.title = title;
         this.content = content;
+        this.reason = reason;
+        if (images != null) {
+            this.images.addAll(images);
+            this.images.forEach(image -> image.setReport(this));
+        }
     }
 }

--- a/src/main/java/com/team/buddyya/report/domain/Report.java
+++ b/src/main/java/com/team/buddyya/report/domain/Report.java
@@ -40,9 +40,6 @@ public class Report {
     @Column(name = "reason", columnDefinition = "TEXT", nullable = false)
     private String reason;
 
-//    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<ReportImage> images = new ArrayList<>();
-
     @Builder
     public Report(ReportType type, Long reportedId, Long reportUserId, Long reportedUserId,
                   String title, String content, String reason) {
@@ -53,9 +50,5 @@ public class Report {
         this.title = title;
         this.content = content;
         this.reason = reason;
-//        if (images != null) {
-//            this.images.addAll(images);
-//            this.images.forEach(image -> image.setReport(this));
-//        }
     }
 }

--- a/src/main/java/com/team/buddyya/report/domain/Report.java
+++ b/src/main/java/com/team/buddyya/report/domain/Report.java
@@ -5,9 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -43,12 +40,12 @@ public class Report {
     @Column(name = "reason", columnDefinition = "TEXT", nullable = false)
     private String reason;
 
-    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ReportImage> images = new ArrayList<>();
+//    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<ReportImage> images = new ArrayList<>();
 
     @Builder
     public Report(ReportType type, Long reportedId, Long reportUserId, Long reportedUserId,
-                  String title, String content, String reason, List<ReportImage> images) {
+                  String title, String content, String reason) {
         this.type = type;
         this.reportedId = reportedId;
         this.reportUserId = reportUserId;
@@ -56,9 +53,9 @@ public class Report {
         this.title = title;
         this.content = content;
         this.reason = reason;
-        if (images != null) {
-            this.images.addAll(images);
-            this.images.forEach(image -> image.setReport(this));
-        }
+//        if (images != null) {
+//            this.images.addAll(images);
+//            this.images.forEach(image -> image.setReport(this));
+//        }
     }
 }

--- a/src/main/java/com/team/buddyya/report/domain/ReportImage.java
+++ b/src/main/java/com/team/buddyya/report/domain/ReportImage.java
@@ -26,11 +26,8 @@ public class ReportImage {
     private String imageUrl;
 
     @Builder
-    public ReportImage(String imageUrl) {
+    public ReportImage(String imageUrl, Report report) {
         this.imageUrl = imageUrl;
-    }
-
-    public void setReport(Report report) {
         this.report = report;
     }
 }

--- a/src/main/java/com/team/buddyya/report/domain/ReportImage.java
+++ b/src/main/java/com/team/buddyya/report/domain/ReportImage.java
@@ -1,0 +1,36 @@
+package com.team.buddyya.report.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "report_image")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ReportImage {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private Report report;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Builder
+    public ReportImage(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void setReport(Report report) {
+        this.report = report;
+    }
+}

--- a/src/main/java/com/team/buddyya/report/dto/ReportRequest.java
+++ b/src/main/java/com/team/buddyya/report/dto/ReportRequest.java
@@ -6,6 +6,6 @@ public record ReportRequest(
         ReportType type,
         Long reportedId,
         Long reportedUserId,
-        String content
+        String reason
 ) {
 }

--- a/src/main/java/com/team/buddyya/report/repository/ReportImageRepository.java
+++ b/src/main/java/com/team/buddyya/report/repository/ReportImageRepository.java
@@ -1,0 +1,10 @@
+package com.team.buddyya.report.repository;
+
+import com.team.buddyya.report.domain.ReportImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportImageRepository extends JpaRepository<ReportImage, Long> {
+    List<ReportImage> findByReportId(Long reportId);
+}

--- a/src/main/java/com/team/buddyya/report/repository/ReportImageRepository.java
+++ b/src/main/java/com/team/buddyya/report/repository/ReportImageRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ReportImageRepository extends JpaRepository<ReportImage, Long> {
+
     List<ReportImage> findByReportId(Long reportId);
 }

--- a/src/main/java/com/team/buddyya/report/service/ReportService.java
+++ b/src/main/java/com/team/buddyya/report/service/ReportService.java
@@ -1,7 +1,10 @@
 package com.team.buddyya.report.service;
 
 import com.team.buddyya.auth.domain.StudentInfo;
+import com.team.buddyya.chatting.service.ChatService;
+import com.team.buddyya.feed.service.CommentService;
 import com.team.buddyya.report.domain.Report;
+import com.team.buddyya.report.domain.ReportType;
 import com.team.buddyya.report.dto.ReportRequest;
 import com.team.buddyya.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReportService {
 
     private final ReportRepository reportRepository;
+    private final CommentService commentService;
+    private final ChatService chatService;
 
     public void createReport(StudentInfo studentInfo, ReportRequest request) {
+        validateReportedContent(request.type(), request.reportedId());
         Report report = Report.builder()
                 .type(request.type())
                 .reportedId(request.reportedId())
@@ -24,5 +30,19 @@ public class ReportService {
                 .content(request.content())
                 .build();
         reportRepository.save(report);
+    }
+
+    private void validateReportedContent(ReportType type, Long id) {
+        switch (type) {
+            case FEED:
+                commentService.findFeedByFeedId(id);
+                break;
+            case COMMENT:
+                commentService.findCommentByCommentId(id);
+                break;
+            case CHATROOM:
+                chatService.findByChatroomByChatroomId(id);
+                break;
+        }
     }
 }

--- a/src/main/java/com/team/buddyya/report/service/ReportService.java
+++ b/src/main/java/com/team/buddyya/report/service/ReportService.java
@@ -8,6 +8,7 @@ import com.team.buddyya.report.domain.Report;
 import com.team.buddyya.report.domain.ReportImage;
 import com.team.buddyya.report.domain.ReportType;
 import com.team.buddyya.report.dto.ReportRequest;
+import com.team.buddyya.report.repository.ReportImageRepository;
 import com.team.buddyya.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class ReportService {
     private final FeedService feedService;
     private final CommentService commentService;
     private final ChatService chatService;
+    private final ReportImageRepository reportImageRepository;
 
     public void createReport(StudentInfo studentInfo, ReportRequest request) {
         validateReportedContent(request.type(), request.reportedId());
@@ -36,9 +38,10 @@ public class ReportService {
                 .title(getTitle(request))
                 .content(getContent(request))
                 .reason(request.reason())
-                .images(getReportImages(request))
                 .build();
         reportRepository.save(report);
+        List<ReportImage> reportImages = getReportImages(request, report);
+        reportImages.forEach(reportImageRepository::save);
     }
 
     private String getTitle(ReportRequest request) {
@@ -57,13 +60,13 @@ public class ReportService {
         return null;
     }
 
-    private List<ReportImage> getReportImages(ReportRequest request) {
+    private List<ReportImage> getReportImages(ReportRequest request, Report report) {
         if (request.type() == ReportType.FEED) {
             return feedService.findFeedByFeedId(request.reportedId()).getImages().stream()
-                    .map(image -> new ReportImage(image.getUrl()))
+                    .map(image -> new ReportImage(image.getUrl(), report))
                     .collect(Collectors.toList());
         }
-        return null;
+        return List.of();
     }
 
     private void validateReportedContent(ReportType type, Long id) {

--- a/src/main/java/com/team/buddyya/report/service/ReportService.java
+++ b/src/main/java/com/team/buddyya/report/service/ReportService.java
@@ -1,9 +1,16 @@
 package com.team.buddyya.report.service;
 
 import com.team.buddyya.auth.domain.StudentInfo;
-import com.team.buddyya.chatting.service.ChatService;
-import com.team.buddyya.feed.service.CommentService;
-import com.team.buddyya.feed.service.FeedService;
+import com.team.buddyya.chatting.domain.Chatroom;
+import com.team.buddyya.chatting.exception.ChatException;
+import com.team.buddyya.chatting.exception.ChatExceptionType;
+import com.team.buddyya.chatting.repository.ChatroomRepository;
+import com.team.buddyya.feed.domain.Comment;
+import com.team.buddyya.feed.domain.Feed;
+import com.team.buddyya.feed.exception.FeedException;
+import com.team.buddyya.feed.exception.FeedExceptionType;
+import com.team.buddyya.feed.repository.CommentRepository;
+import com.team.buddyya.feed.repository.FeedRepository;
 import com.team.buddyya.report.domain.Report;
 import com.team.buddyya.report.domain.ReportImage;
 import com.team.buddyya.report.domain.ReportType;
@@ -23,16 +30,16 @@ import java.util.stream.Collectors;
 public class ReportService {
 
     private final ReportRepository reportRepository;
-    private final FeedService feedService;
-    private final CommentService commentService;
-    private final ChatService chatService;
+    private final ChatroomRepository chatRoomRepository;
+    private final FeedRepository feedRepository;
+    private final CommentRepository commentRepository;
     private final ReportImageRepository reportImageRepository;
 
     public void createReport(StudentInfo studentInfo, ReportRequest request) {
         validateReportedContent(request.type(), request.reportedId());
         Report report = Report.builder()
                 .type(request.type())
-                .reportedId(request.type() == ReportType.CHATROOM ? request.reportedId() : null)
+                .reportedId(getReportedId(request))
                 .reportUserId(studentInfo.id())
                 .reportedUserId(request.reportedUserId())
                 .title(getTitle(request))
@@ -46,23 +53,30 @@ public class ReportService {
 
     private String getTitle(ReportRequest request) {
         if (request.type() == ReportType.FEED) {
-            return feedService.findFeedByFeedId(request.reportedId()).getTitle();
+            return findFeedById(request.reportedId()).getTitle();
         }
         return null;
     }
 
     private String getContent(ReportRequest request) {
         if (request.type() == ReportType.FEED) {
-            return feedService.findFeedByFeedId(request.reportedId()).getContent();
+            return findFeedById(request.reportedId()).getContent();
         } else if (request.type() == ReportType.COMMENT) {
-            return commentService.findCommentByCommentId(request.reportedId()).getContent();
+            return findCommentById(request.reportedId()).getContent();
+        }
+        return null;
+    }
+
+    private Long getReportedId(ReportRequest request) {
+        if (request.type() == ReportType.CHATROOM) {
+            return request.reportedId();
         }
         return null;
     }
 
     private List<ReportImage> getReportImages(ReportRequest request, Report report) {
         if (request.type() == ReportType.FEED) {
-            return feedService.findFeedByFeedId(request.reportedId()).getImages().stream()
+            return findFeedById(request.reportedId()).getImages().stream()
                     .map(image -> new ReportImage(image.getUrl(), report))
                     .collect(Collectors.toList());
         }
@@ -72,14 +86,29 @@ public class ReportService {
     private void validateReportedContent(ReportType type, Long id) {
         switch (type) {
             case FEED:
-                feedService.findFeedByFeedId(id);
+                findFeedById(id);
                 break;
             case COMMENT:
-                commentService.findCommentByCommentId(id);
+                findCommentById(id);
                 break;
             case CHATROOM:
-                chatService.findByChatroomByChatroomId(id);
+                findByChatroomByChatroomId(id);
                 break;
         }
+    }
+
+    private Feed findFeedById(Long feedId) {
+        return feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
+    }
+
+    private Comment findCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new FeedException(FeedExceptionType.COMMENT_NOT_FOUND));
+    }
+
+    private Chatroom findByChatroomByChatroomId(Long chatroomId) {
+        return chatRoomRepository.findById(chatroomId)
+                .orElseThrow(() -> new ChatException(ChatExceptionType.CHATROOM_NOT_FOUND));
     }
 }

--- a/src/main/java/com/team/buddyya/report/service/ReportService.java
+++ b/src/main/java/com/team/buddyya/report/service/ReportService.java
@@ -3,7 +3,9 @@ package com.team.buddyya.report.service;
 import com.team.buddyya.auth.domain.StudentInfo;
 import com.team.buddyya.chatting.service.ChatService;
 import com.team.buddyya.feed.service.CommentService;
+import com.team.buddyya.feed.service.FeedService;
 import com.team.buddyya.report.domain.Report;
+import com.team.buddyya.report.domain.ReportImage;
 import com.team.buddyya.report.domain.ReportType;
 import com.team.buddyya.report.dto.ReportRequest;
 import com.team.buddyya.report.repository.ReportRepository;
@@ -11,12 +13,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ReportService {
 
     private final ReportRepository reportRepository;
+    private final FeedService feedService;
     private final CommentService commentService;
     private final ChatService chatService;
 
@@ -24,18 +30,46 @@ public class ReportService {
         validateReportedContent(request.type(), request.reportedId());
         Report report = Report.builder()
                 .type(request.type())
-                .reportedId(request.reportedId())
+                .reportedId(request.type() == ReportType.CHATROOM ? request.reportedId() : null)
                 .reportUserId(studentInfo.id())
                 .reportedUserId(request.reportedUserId())
-                .content(request.content())
+                .title(getTitle(request))
+                .content(getContent(request))
+                .reason(request.reason())
+                .images(getReportImages(request))
                 .build();
         reportRepository.save(report);
+    }
+
+    private String getTitle(ReportRequest request) {
+        if (request.type() == ReportType.FEED) {
+            return feedService.findFeedByFeedId(request.reportedId()).getTitle();
+        }
+        return null;
+    }
+
+    private String getContent(ReportRequest request) {
+        if (request.type() == ReportType.FEED) {
+            return feedService.findFeedByFeedId(request.reportedId()).getContent();
+        } else if (request.type() == ReportType.COMMENT) {
+            return commentService.findCommentByCommentId(request.reportedId()).getContent();
+        }
+        return null;
+    }
+
+    private List<ReportImage> getReportImages(ReportRequest request) {
+        if (request.type() == ReportType.FEED) {
+            return feedService.findFeedByFeedId(request.reportedId()).getImages().stream()
+                    .map(image -> new ReportImage(image.getUrl()))
+                    .collect(Collectors.toList());
+        }
+        return null;
     }
 
     private void validateReportedContent(ReportType type, Long id) {
         switch (type) {
             case FEED:
-                commentService.findFeedByFeedId(id);
+                feedService.findFeedByFeedId(id);
                 break;
             case COMMENT:
                 commentService.findCommentByCommentId(id);

--- a/src/main/resources/db/migration/V3__Update_Report_Table.sql
+++ b/src/main/resources/db/migration/V3__Update_Report_Table.sql
@@ -1,0 +1,15 @@
+ALTER TABLE report CHANGE COLUMN content reason TEXT NOT NULL;
+
+ALTER TABLE report ADD COLUMN content TEXT NULL;
+
+ALTER TABLE report MODIFY COLUMN reported_id BIGINT NULL;
+
+ALTER TABLE report ADD COLUMN title VARCHAR(255) NULL;
+
+CREATE TABLE report_image
+(
+    id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+    report_id BIGINT       NOT NULL,
+    image_url VARCHAR(500) NOT NULL,
+    FOREIGN KEY (report_id) REFERENCES report (id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## 📌 관련 이슈
[신고 시 저장 내용 수정 & 관리자 신고 조회 [#136]](https://github.com/buddy-ya/be/issues/136)
<br><br>

## 🛠️ 작업 내용
- 신고된 컨텐츠에 대한 내용 직접 저장하도록 수정
- 신고 목록 상세 조회
<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가

## 🤔 고민한 부분
### 기존 문제점
기존에는 Feed, Comment, Chatroom에 대한 신고가 하나의 API에서 type과 신고된 ID (feedId, commentId, chatroomId)만 저장하는 방식이었습니다.

그러나 **신고된 게시글이나 댓글이 삭제되거나 수정**될 경우, **신고 내역을 조회할 때 해당 데이터(수정 시 원본 데이터)를 찾을 수 없는 문제**가 발생했습니다.

### 처음에 고민한 해결 방법 
**Feed 및 Comment에 isReport, isDeleted 필드 추가**
삭제 시 신고된 경우 삭제하지 않고 isDeleted = true로 표시하여 사용자에게만 숨기기
-> 모든 게시글과 댓글에서 신고 및 삭제 상태를 검사해야 하므로 비효율적이라고 생각하였습니다

### 개선된 구현 방식
신고 시 Report 도메인에 **직접 필요한 데이터를 저장**

FeedId, CommentId를 참조하지 않고, title, content, imageUrls 등을 Report 엔티티에 직접 저장합니다.
원본 데이터가 삭제되더라도 **신고 내역이 유지되므로 신고 조회 시 데이터 유실 문제 해결**할 수 있습니다.

단, Chatroom의 경우 reportedId(chatroomId)만 저장합니다
**모든 메시지를 Report에 저장하는 것은 비효율적**이므로, chatroomId만 저장하고 신고된 채팅 메시지는 별도로 조회합니다.

### 고민할 점 및 추가 논의 사항
이번 변경으로 인해 명수님이 저번 PR에 하셨던 고민과 마찬가지로 type에 따라 **null이 들어가는 필드가 발생하는 문제**가 있습니다.
ex) Feed 신고에서는 title, content, imageUrls이 저장되지만, Comment와 Chatroom 신고에서는 필요하지 않음

더 좋은 데이터 구조가 있다면 논의해 보면 좋겠습니다! 

추가적으로 flyway를 적용한 이후 개발 환경에서도 테스트할 경우 DB 스크립트를 작성하고, 테스트 과정에서 실패하여 변경이 필요한 경우, DB를 원상태로 돌리기 위한 과정에서 번거로움이 있는 것 같습니다.
대면으로 논의해봐도 좋을 것 같습니다!
<br><br>

## 📎 커밋 범위 링크

<br><br>
