### PR TITLE
feat: 포인트 기능

### DIFF
--- a/src/main/java/com/team/buddyya/student/domain/Block.java
+++ b/src/main/java/com/team/buddyya/student/domain/Block.java
@@ -1,5 +1,6 @@
 package com.team.buddyya.student.domain;
 
+import com.team.buddyya.common.domain.CreatedTime;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "block")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Block {
+public class Block extends CreatedTime{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/team/buddyya/student/domain/Point.java
+++ b/src/main/java/com/team/buddyya/student/domain/Point.java
@@ -15,12 +15,12 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Point extends BaseTime {
 
+    private static final int MIN_POINT = 0;
+    private static final int MAX_POINT = 100_000;
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
-
-    private static final int MIN_POINT = 0;
-    private static final int MAX_POINT = 100_000;
 
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "student_id", nullable = false, unique = true)

--- a/src/main/java/com/team/buddyya/student/domain/Point.java
+++ b/src/main/java/com/team/buddyya/student/domain/Point.java
@@ -19,6 +19,7 @@ public class Point extends BaseTime {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
+    private static final int MIN_POINT = 0;
     private static final int MAX_POINT = 100_000;
 
     @OneToOne(fetch = LAZY)
@@ -41,7 +42,7 @@ public class Point extends BaseTime {
     }
 
     private void validatePoint(int point) {
-        if (point < 0) {
+        if (point < MIN_POINT) {
             throw new StudentException(StudentExceptionType.NEGATIVE_POINT);
         }
         if (point > MAX_POINT) {

--- a/src/main/java/com/team/buddyya/student/domain/Point.java
+++ b/src/main/java/com/team/buddyya/student/domain/Point.java
@@ -1,0 +1,51 @@
+package com.team.buddyya.student.domain;
+
+import com.team.buddyya.common.domain.BaseTime;
+import com.team.buddyya.student.exception.StudentException;
+import com.team.buddyya.student.exception.StudentExceptionType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(name = "point")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Point extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private static final int MAX_POINT = 100_000;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "student_id", nullable = false, unique = true)
+    private Student student;
+
+    @Column(name = "current_point", nullable = false)
+    private Integer currentPoint;
+
+    @Builder
+    public Point(Student student, int currentPoint) {
+        this.student = student;
+        this.currentPoint = currentPoint;
+    }
+
+    public void updatePoint(int pointChange) {
+        int newPoint = this.currentPoint + pointChange;
+        validatePoint(newPoint);
+        this.currentPoint = newPoint;
+    }
+
+    private void validatePoint(int point) {
+        if (point < 0) {
+            throw new StudentException(StudentExceptionType.NEGATIVE_POINT);
+        }
+        if (point > MAX_POINT) {
+            throw new StudentException(StudentExceptionType.EXCEED_MAX_POINT);
+        }
+    }
+}

--- a/src/main/java/com/team/buddyya/student/domain/PointStatus.java
+++ b/src/main/java/com/team/buddyya/student/domain/PointStatus.java
@@ -1,0 +1,37 @@
+package com.team.buddyya.student.domain;
+
+import com.team.buddyya.common.domain.CreatedTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(name = "point_status")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointStatus extends CreatedTime {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "point_id", nullable = false)
+    private Point point;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "point_type", nullable = false)
+    private PointType pointType;
+
+    @Column(name = "changed_point", nullable = false)
+    private Integer changedPoint;
+
+    @Builder
+    public PointStatus(Point point, PointType pointType, int changedPoint) {
+        this.point = point;
+        this.pointType = pointType;
+        this.changedPoint = changedPoint;
+    }
+}

--- a/src/main/java/com/team/buddyya/student/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/student/domain/PointType.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 @Getter
 public enum PointType {
 
-    INITIAL("initial", 0),
     SIGNUP("signup", 1),
     UNIVERSITY_AUTH("university_auth",1),
     CHAT_REQUEST("chat_request", -1),

--- a/src/main/java/com/team/buddyya/student/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/student/domain/PointType.java
@@ -1,0 +1,32 @@
+package com.team.buddyya.student.domain;
+
+import com.team.buddyya.student.exception.StudentException;
+import com.team.buddyya.student.exception.StudentExceptionType;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum PointType {
+
+    INITIAL("initial", 0),
+    SIGNUP("signup", 1),
+    UNIVERSITY_AUTH("university_auth",1),
+    CHAT_REQUEST("chat_request", -1),
+    MATCH_REQUEST("match_request", -1);
+
+    private final String displayName;
+    private final int pointChange;
+
+    PointType(String displayName, int pointChange) {
+        this.displayName = displayName;
+        this.pointChange = pointChange;
+    }
+
+    public static PointType fromValue(String displayName) {
+        return Arrays.stream(PointType.values())
+                .filter(type -> type.getDisplayName().equals(displayName))
+                .findFirst()
+                .orElseThrow(() -> new StudentException(StudentExceptionType.INVALID_POINT_TYPE));
+    }
+}

--- a/src/main/java/com/team/buddyya/student/exception/StudentExceptionType.java
+++ b/src/main/java/com/team/buddyya/student/exception/StudentExceptionType.java
@@ -19,7 +19,8 @@ public enum StudentExceptionType implements BaseExceptionType {
     ALREADY_BLOCKED(2011, HttpStatus.CONFLICT, "이미 차단된 사용자입니다."),
     INVALID_POINT_TYPE(2012, HttpStatus.BAD_REQUEST, "유효하지 않는 포인트 타입입니다."),
     NEGATIVE_POINT(2013, HttpStatus.BAD_REQUEST, "포인트는 0 미만이 될 수 없습니다."),
-    EXCEED_MAX_POINT(2014, HttpStatus.BAD_REQUEST, "최대 보유 포인트를 초과할 수 없습니다.");
+    EXCEED_MAX_POINT(2014, HttpStatus.BAD_REQUEST, "최대 보유 포인트를 초과할 수 없습니다."),
+    POINT_NOT_FOUND(2015, HttpStatus.NOT_FOUND, "해당 학생의 포인트가 존재하지 않습니다");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/student/exception/StudentExceptionType.java
+++ b/src/main/java/com/team/buddyya/student/exception/StudentExceptionType.java
@@ -16,7 +16,10 @@ public enum StudentExceptionType implements BaseExceptionType {
     INVALID_NAME_UPDATE_REQUEST(2001, HttpStatus.BAD_REQUEST, "이름 업데이트에는 하나의 값만 필요합니다."),
     UNSUPPORTED_UPDATE_KEY(2002, HttpStatus.BAD_REQUEST, "지원되지 않는 업데이트 키입니다."),
     CANNOT_BLOCK_SELF(2010, HttpStatus.BAD_REQUEST, "자기 자신을 차단할 수 없습니다."),
-    ALREADY_BLOCKED(2011, HttpStatus.CONFLICT, "이미 차단된 사용자입니다.");
+    ALREADY_BLOCKED(2011, HttpStatus.CONFLICT, "이미 차단된 사용자입니다."),
+    INVALID_POINT_TYPE(2012, HttpStatus.BAD_REQUEST, "유효하지 않는 포인트 타입입니다."),
+    NEGATIVE_POINT(2013, HttpStatus.BAD_REQUEST, "포인트는 0 미만이 될 수 없습니다."),
+    EXCEED_MAX_POINT(2014, HttpStatus.BAD_REQUEST, "최대 보유 포인트를 초과할 수 없습니다.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/student/repository/PointRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/PointRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
+
     Optional<Point> findByStudent(Student student);
 }

--- a/src/main/java/com/team/buddyya/student/repository/PointRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/PointRepository.java
@@ -1,0 +1,11 @@
+package com.team.buddyya.student.repository;
+
+import com.team.buddyya.student.domain.Point;
+import com.team.buddyya.student.domain.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PointRepository extends JpaRepository<Point, Long> {
+    Optional<Point> findByStudent(Student student);
+}

--- a/src/main/java/com/team/buddyya/student/repository/PointStatusRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/PointStatusRepository.java
@@ -1,0 +1,7 @@
+package com.team.buddyya.student.repository;
+
+import com.team.buddyya.student.domain.PointStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointStatusRepository extends JpaRepository<PointStatus, Long> {
+}

--- a/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
+++ b/src/main/java/com/team/buddyya/student/service/OnBoardingService.java
@@ -4,6 +4,7 @@ import com.team.buddyya.auth.domain.AuthToken;
 import com.team.buddyya.auth.dto.request.TokenInfoRequest;
 import com.team.buddyya.auth.jwt.JwtUtils;
 import com.team.buddyya.auth.repository.AuthTokenRepository;
+import com.team.buddyya.student.domain.Point;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.dto.request.OnBoardingRequest;
 import com.team.buddyya.student.dto.response.UserResponse;
@@ -22,6 +23,7 @@ public class OnBoardingService {
     private final StudentLanguageService studentLanguageService;
     private final StudentMajorService studentMajorService;
     private final ProfileImageService profileImageService;
+    private final PointService pointService;
     private final AuthTokenRepository authTokenRepository;
     private final JwtUtils jwtUtils;
 
@@ -34,6 +36,7 @@ public class OnBoardingService {
         studentMajorService.createStudentMajors(request.majors(), student);
         studentInterestService.createStudentInterests(request.interests(), student);
         studentLanguageService.createStudentLanguages(request.languages(), student);
+        pointService.createPoint(student);
         return UserResponse.from(student, false, accessToken, refreshToken);
     }
 

--- a/src/main/java/com/team/buddyya/student/service/PointService.java
+++ b/src/main/java/com/team/buddyya/student/service/PointService.java
@@ -40,4 +40,23 @@ public class PointService {
         pointStatusRepository.save(signUpPointStatus);
         return point;
     }
+
+    public void updatePoint(Student student, String pointTypeValue){
+        Point point = getPoint(student);
+        PointType pointType = PointType.fromValue(pointTypeValue);
+        int pointChange = pointType.getPointChange();
+        point.updatePoint(pointChange);
+        pointRepository.save(point);
+        PointStatus pointStatus = PointStatus.builder()
+                .point(point)
+                .pointType(pointType)
+                .changedPoint(pointChange)
+                .build();
+        pointStatusRepository.save(pointStatus);
+    }
+
+    public Point getPoint(Student student){
+        return pointRepository.findByStudent(student)
+                .orElseGet(() -> Point.builder().student(student).currentPoint(0).build());
+    }
 }

--- a/src/main/java/com/team/buddyya/student/service/PointService.java
+++ b/src/main/java/com/team/buddyya/student/service/PointService.java
@@ -28,12 +28,6 @@ public class PointService {
                 .currentPoint(INITIAL_POINT)
                 .build();
         pointRepository.save(point);
-        PointStatus intialPointStatus = PointStatus.builder()
-                .point(point)
-                .pointType(PointType.INITIAL)
-                .changedPoint(PointType.INITIAL.getPointChange())
-                .build();
-        pointStatusRepository.save(intialPointStatus);
         PointStatus signUpPointStatus = PointStatus.builder()
                 .point(point)
                 .pointType(PointType.SIGNUP)

--- a/src/main/java/com/team/buddyya/student/service/PointService.java
+++ b/src/main/java/com/team/buddyya/student/service/PointService.java
@@ -1,0 +1,43 @@
+package com.team.buddyya.student.service;
+
+import com.team.buddyya.student.domain.Point;
+import com.team.buddyya.student.domain.PointStatus;
+import com.team.buddyya.student.domain.PointType;
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.repository.PointRepository;
+import com.team.buddyya.student.repository.PointStatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PointService {
+
+    private final PointRepository pointRepository;
+    private final PointStatusRepository pointStatusRepository;
+
+    private static final int INITIAL_POINT = 1;
+
+    public Point createPoint(Student student) {
+        Point point = Point.builder()
+                .student(student)
+                .currentPoint(INITIAL_POINT)
+                .build();
+        pointRepository.save(point);
+        PointStatus intialPointStatus = PointStatus.builder()
+                .point(point)
+                .pointType(PointType.INITIAL)
+                .changedPoint(PointType.INITIAL.getPointChange())
+                .build();
+        pointStatusRepository.save(intialPointStatus);
+        PointStatus signUpPointStatus = PointStatus.builder()
+                .point(point)
+                .pointType(PointType.SIGNUP)
+                .changedPoint(PointType.SIGNUP.getPointChange())
+                .build();
+        pointStatusRepository.save(signUpPointStatus);
+        return point;
+    }
+}

--- a/src/main/java/com/team/buddyya/student/service/PointService.java
+++ b/src/main/java/com/team/buddyya/student/service/PointService.java
@@ -20,7 +20,7 @@ public class PointService {
 
     private static final int INITIAL_POINT = 1;
 
-    public Point createPoint(Student student) {
+    public void createPoint(Student student) {
         Point point = Point.builder()
                 .student(student)
                 .currentPoint(INITIAL_POINT)
@@ -38,7 +38,6 @@ public class PointService {
                 .changedPoint(PointType.SIGNUP.getPointChange())
                 .build();
         pointStatusRepository.save(signUpPointStatus);
-        return point;
     }
 
     public void updatePoint(Student student, String pointTypeValue){

--- a/src/main/java/com/team/buddyya/student/service/PointService.java
+++ b/src/main/java/com/team/buddyya/student/service/PointService.java
@@ -42,9 +42,8 @@ public class PointService {
         pointStatusRepository.save(signUpPointStatus);
     }
 
-    public void updatePoint(Student student, String pointTypeValue){
+    public void updatePoint(Student student, PointType pointType){
         Point point = getPoint(student);
-        PointType pointType = PointType.fromValue(pointTypeValue);
         int pointChange = pointType.getPointChange();
         point.updatePoint(pointChange);
         pointRepository.save(point);

--- a/src/main/java/com/team/buddyya/student/service/PointService.java
+++ b/src/main/java/com/team/buddyya/student/service/PointService.java
@@ -4,6 +4,8 @@ import com.team.buddyya.student.domain.Point;
 import com.team.buddyya.student.domain.PointStatus;
 import com.team.buddyya.student.domain.PointType;
 import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.exception.StudentException;
+import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.PointRepository;
 import com.team.buddyya.student.repository.PointStatusRepository;
 import lombok.RequiredArgsConstructor;
@@ -54,8 +56,8 @@ public class PointService {
         pointStatusRepository.save(pointStatus);
     }
 
-    public Point getPoint(Student student){
+    public Point getPoint(Student student) {
         return pointRepository.findByStudent(student)
-                .orElseGet(() -> Point.builder().student(student).currentPoint(0).build());
+                .orElseThrow(() -> new StudentException(StudentExceptionType.POINT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/team/buddyya/student/service/PointService.java
+++ b/src/main/java/com/team/buddyya/student/service/PointService.java
@@ -40,7 +40,6 @@ public class PointService {
         Point point = getPoint(student);
         int pointChange = pointType.getPointChange();
         point.updatePoint(pointChange);
-        pointRepository.save(point);
         PointStatus pointStatus = PointStatus.builder()
                 .point(point)
                 .pointType(pointType)

--- a/src/main/java/com/team/buddyya/student/service/PointService.java
+++ b/src/main/java/com/team/buddyya/student/service/PointService.java
@@ -15,10 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class PointService {
 
+    private static final int INITIAL_POINT = 1;
+
     private final PointRepository pointRepository;
     private final PointStatusRepository pointStatusRepository;
-
-    private static final int INITIAL_POINT = 1;
 
     public void createPoint(Student student) {
         Point point = Point.builder()

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -45,9 +45,6 @@ public class StudentService {
     private final ExpoTokenRepository expoTokenRepository;
     private final RegisteredPhoneRepository registeredPhoneRepository;
     private final StudentEmailRepository studentEmailRepository;
-    private final StudentMajorRepository studentMajorRepository;
-    private final StudentLanguageRepository studentLanguageRepository;
-    private final StudentInterestRepository studentInterestRepository;
 
     private static final String BLOCK_SUCCESS_MESSAGE = "차단이 성공적으로 완료되었습니다.";
 

--- a/src/main/resources/db/migration/V9__Create_point_table.sql
+++ b/src/main/resources/db/migration/V9__Create_point_table.sql
@@ -1,0 +1,34 @@
+CREATE TABLE point
+(
+    id            BIGINT AUTO_INCREMENT NOT NULL,
+    created_date  datetime NOT NULL,
+    updated_date  datetime NOT NULL,
+    student_id    BIGINT   NOT NULL,
+    current_point INT      NOT NULL,
+    CONSTRAINT pk_point PRIMARY KEY (id)
+);
+
+CREATE TABLE point_status
+(
+    id            BIGINT AUTO_INCREMENT NOT NULL,
+    created_date  datetime     NOT NULL,
+    point_id      BIGINT       NOT NULL,
+    point_type    VARCHAR(255) NOT NULL,
+    changed_point INT          NOT NULL,
+    CONSTRAINT pk_point_status PRIMARY KEY (id)
+);
+
+ALTER TABLE block
+    ADD created_date datetime NULL;
+
+ALTER TABLE block
+    MODIFY created_date datetime NOT NULL;
+
+ALTER TABLE point
+    ADD CONSTRAINT uc_point_student UNIQUE (student_id);
+
+ALTER TABLE point
+    ADD CONSTRAINT FK_POINT_ON_STUDENT FOREIGN KEY (student_id) REFERENCES student (id);
+
+ALTER TABLE point_status
+    ADD CONSTRAINT FK_POINT_STATUS_ON_POINT FOREIGN KEY (point_id) REFERENCES point (id);


### PR DESCRIPTION
## 📌 관련 이슈
[포인트(티켓) 기능](https://github.com/buddy-ya/be/issues/139)[#139]

<br><br>

## 🛠️ 작업 내용
### Point
- Student(학생)와 1:1 매핑되는 엔티티로, 현재 보유한 포인트 총합을 관리함.
- BaseTime을 상속받아 생성 및 업데이트 시간 자동 저장.
- 최대 포인트 제한 (MAX_POINT = 100,000) 및 포인트 감소 방지 (0 미만 불가).

### PointStatus
- Point와 N:1 매핑되는 엔티티로, 포인트 변화 이력을 저장함.
- CreatedTime을 상속받아 생성 시간 자동 저장.

### PointType (Enum)
- 포인트가 증가/감소하는 이유를 나타내는 열거형(Enum).
- 각 타입마다 변동되는 포인트 값(pointChange)이 설정됨

### PointService : 회원 가입 포인트를 제외하고 아직 구현하지 않음
- `createPoint`: 온보딩 시 호출하여 학생의 초기 포인트를 생성하는 메서드.
초기 포인트(INITIAL)와 회원가입 포인트(SIGNUP) 상태(PointStatus)를 함께 저장.
- `updatePoint`: 특정 PointType을 기반으로 포인트를 변경.
포인트 업데이트 후 변화 이력(PointStatus)을 저장.

### 포인트 증가, 감소 상황/값, 포인트의 상향선 같은 부분은 임의로 제가 정한 부분이라 추후에 수정이 필요 

### refactor: Block 엔티티에 CreatedTime 상속 추가 -> **반드시 마이그레이션 파일에 추가해야됨**

<br><br>

## 🎯 리뷰 포인트

### 1️⃣ Point를 별도 엔티티로 관리할지, Student의 필드로 둘지?
Student의 필드로 두면 포인트 관련 로직을 Student 엔티티가 직접 담당하게 되어 역할이 분리되지 않아서
Point를 **별도 엔티티로 관리하는 것이 적절하다고 판단**하였습니다.

### 2️⃣ Point 값의 실제 Type으로 Integer가 적당한지?
- int를 사용하지 않은 이유 (기본 타입)
-> Point 값이 초기화되지 않거나, 특정 조건에서 null이 들어갈 수 있다면 int를 사용할 수 없기 때문
- long, Long을 사용하지 않은 이유
-> Integer의 범위인 -2,147,483,648 ~ 2,147,483,647로도 충분할 거 같아서

### 3️⃣ `PointType`을 Enum vs 엔티티 으로 관리

`Enum으로 관리할 경우`
- PointType을 조회할 때마다 DB를 조회하지 않고 바로 Enum에서 값을 찾을 수 있음.
- 변경 시 애플리케이션 코드만 수정하면 되므로 유지보수가 쉬움.
- 추가적인 테이블 관리가 필요 없음.

**하지만** 변경 사항이 생길 경우에 변경하려면 코드 수정 후 배포가 필요하다.

`엔티티로 관리 할 경우`
- 운영 중에도 새로운 포인트 정책을 추가/수정 가능

**하지만** 포인트 정책을 확인할 때마다 DB 조회가 발생하고 단순한 포인트 증감 이유를 관리하는데
불필요한 복잡성이 추가될 수 있다.

**결론**
최종적으로 PointType은 자주 변경되지 않는 "정책성 데이터"라고 판단해 `Enum으로 관리`하도록 하였지만,
현실적으로 자주 변경될 거 같아서 어떻게 관리할 지 논의를 해보았으면 좋겠습니다.

### 4️⃣ 탈퇴시 액션?
현재 탈퇴 시 다른 기능에 영향을 주지 않고, 남은 포인트는 어떻게 해야될 지 정해지지 않아
포인트와 관련된 엔티티는 삭제하지 않고 남겨두었습니다.

### 5️⃣ 포인트 조회 API vs 유저 정보에 포함해서 반환
유저 정보에 포함해서 반환할 경우 포인트 조회가 유저 정보 조회할 때에 한정되는 느낌이라
따로 두는게 좋을거 같은데 혹시 어떻게 생각하시는지 궁금합니다. 

## ✏️ 알게된 점(참고) -> 리뷰 후`OrElseThrow()`로 수정
### `OrElse()` vs `OrElseGet()`
```
    public Point getPoint(Student student){
        return pointRepository.findByStudent(student)
                .orElseGet(() -> Point.builder().student(student).currentPoint(0).build());
    }
```
`orElse()`는 Optional이 비어있든 말든 Point.builder()를 항상 실행.
즉, findByStudent(student)가 값을 가져왔을 때도 불필요하게 Point.builder()가 실행됨.
결과적으로 생성된 객체가 사용되지 않고 GC(가비지 컬렉터)에 의해 제거됨 → 성능 낭비 발생.
`orElseGet()`를 사용하면 Point가 이미 존재할 때 Point.builder()를 실행하지 않아 
성능을 조금 더 최적화시킬 수 있다고 합니다.

<br><br>

## 📎 커밋 범위 링크

<br><br>
