### PR TITLE
feat: 관리자 제재 기능 및 학생증 반려 사유 추가

### DIFF
--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -1,7 +1,9 @@
 package com.team.buddyya.admin.controller;
 
+import com.team.buddyya.admin.dto.request.BanRequest;
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
-import com.team.buddyya.admin.dto.response.AdminReportsResponse;
+import com.team.buddyya.admin.dto.response.AdminChatMessageResponse;
+import com.team.buddyya.admin.dto.response.AdminReportResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.admin.service.AdminService;

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.team.buddyya.admin.controller;
 
+import com.team.buddyya.admin.dto.request.BanRequest;
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
 import com.team.buddyya.admin.dto.response.AdminReportsResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
@@ -31,5 +32,19 @@ public class AdminController {
     @GetMapping("/reports")
     public ResponseEntity<List<AdminReportsResponse>> getReports() {
         return ResponseEntity.ok(adminService.getAllReports());
+    }
+
+    @PostMapping("/ban/{studentId}")
+    public ResponseEntity<Void> banStudent(
+            @PathVariable("studentId") Long studentId,
+            @RequestBody BanRequest request) {
+        adminService.banStudent(studentId, request.days());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/unban/{studentId}")
+    public ResponseEntity<Void> unbanStudent(@PathVariable("studentId") Long studentId) {
+        adminService.unbanStudent(studentId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -34,7 +34,7 @@ public class AdminController {
         return ResponseEntity.ok(adminService.getAllReports());
     }
 
-    @PostMapping("/ban/{studentId}")
+    @PatchMapping("/ban/{studentId}")
     public ResponseEntity<Void> banStudent(
             @PathVariable("studentId") Long studentId,
             @RequestBody BanRequest request) {
@@ -42,7 +42,7 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/unban/{studentId}")
+    @PatchMapping("/unban/{studentId}")
     public ResponseEntity<Void> unbanStudent(@PathVariable("studentId") Long studentId) {
         adminService.unbanStudent(studentId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.team.buddyya.admin.controller;
 
 import com.team.buddyya.admin.dto.request.BanRequest;
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
+import com.team.buddyya.admin.dto.response.AdminChatMessageResponse;
 import com.team.buddyya.admin.dto.response.AdminReportsResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
@@ -46,5 +47,11 @@ public class AdminController {
     public ResponseEntity<Void> unbanStudent(@PathVariable("studentId") Long studentId) {
         adminService.unbanStudent(studentId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/chatroom/{roomId}/chats")
+    public ResponseEntity<List<AdminChatMessageResponse>> getAllChatMessages(@PathVariable("roomId") Long roomId) {
+        List<AdminChatMessageResponse> response = adminService.getAllChatMessages(roomId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/team/buddyya/admin/dto/request/BanRequest.java
+++ b/src/main/java/com/team/buddyya/admin/dto/request/BanRequest.java
@@ -1,0 +1,6 @@
+package com.team.buddyya.admin.dto.request;
+
+public record BanRequest(
+        int days
+) {
+}

--- a/src/main/java/com/team/buddyya/admin/dto/request/StudentVerificationRequest.java
+++ b/src/main/java/com/team/buddyya/admin/dto/request/StudentVerificationRequest.java
@@ -2,6 +2,8 @@ package com.team.buddyya.admin.dto.request;
 
 public record StudentVerificationRequest(
         Long id,
+        boolean isApproved,
+        String rejectionReason,
         String imageUrl
 ) {
 }

--- a/src/main/java/com/team/buddyya/admin/dto/response/AdminChatMessageResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/AdminChatMessageResponse.java
@@ -1,0 +1,24 @@
+package com.team.buddyya.admin.dto.response;
+
+import com.team.buddyya.chatting.domain.Chat;
+import com.team.buddyya.chatting.domain.MessageType;
+
+import java.time.LocalDateTime;
+
+public record AdminChatMessageResponse(
+        Long id,
+        Long senderId,
+        MessageType type,
+        String message,
+        LocalDateTime createdDate
+) {
+    public static AdminChatMessageResponse from(Chat chat) {
+        return new AdminChatMessageResponse(
+                chat.getId(),
+                chat.getStudent().getId(),
+                chat.getType(),
+                chat.getMessage(),
+                chat.getCreatedDate()
+        );
+    }
+}

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -1,13 +1,16 @@
 package com.team.buddyya.admin.service;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
-import com.team.buddyya.admin.dto.response.AdminReportsResponse;
-import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
-import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
-import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
+import com.team.buddyya.admin.dto.response.*;
 import com.team.buddyya.certification.domain.StudentIdCard;
 import com.team.buddyya.certification.exception.CertificateException;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
+import com.team.buddyya.chatting.domain.Chat;
+import com.team.buddyya.chatting.domain.Chatroom;
+import com.team.buddyya.chatting.exception.ChatException;
+import com.team.buddyya.chatting.exception.ChatExceptionType;
+import com.team.buddyya.chatting.repository.ChatRepository;
+import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.notification.service.NotificationService;
 import com.team.buddyya.report.repository.ReportRepository;
@@ -39,6 +42,8 @@ public class AdminService {
     private final NotificationService notificationService;
     private final StudentIdCardRepository studentIdCardRepository;
     private final ReportRepository reportRepository;
+    private final ChatRepository chatRepository;
+    private final ChatroomRepository chatroomRepository;
 
     @Transactional(readOnly = true)
     public StudentIdCardListResponse getStudentIdCards() {
@@ -79,5 +84,14 @@ public class AdminService {
     public void unbanStudent(Long studentId) {
         Student student = findStudentService.findByStudentId(studentId);
         student.unban();
+    }
+
+    public List<AdminChatMessageResponse> getAllChatMessages(Long chatroomId) {
+        Chatroom chatroom = chatroomRepository.findById(chatroomId)
+                .orElseThrow(() -> new ChatException(ChatExceptionType.CHATROOM_NOT_FOUND));
+        List<Chat> chats = chatRepository.findByChatroom(chatroom);
+        return chats.stream()
+                .map(AdminChatMessageResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -59,4 +59,14 @@ public class AdminService {
                 .map(AdminReportsResponse::from)
                 .collect(Collectors.toList());
     }
+
+    public void banStudent(Long studentId, int days) {
+        Student student = findStudentService.findByStudentId(studentId);
+        student.ban(days);
+    }
+
+    public void unbanStudent(Long studentId) {
+        Student student = findStudentService.findByStudentId(studentId);
+        student.unban();
+    }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -1,13 +1,20 @@
 package com.team.buddyya.admin.service;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
-import com.team.buddyya.admin.dto.response.AdminReportsResponse;
-import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
-import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
-import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
+import com.team.buddyya.admin.dto.response.*;
+import com.team.buddyya.certification.domain.StudentIdCard;
+import com.team.buddyya.certification.exception.CertificateException;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
+import com.team.buddyya.chatting.domain.Chat;
+import com.team.buddyya.chatting.domain.Chatroom;
+import com.team.buddyya.chatting.exception.ChatException;
+import com.team.buddyya.chatting.exception.ChatExceptionType;
+import com.team.buddyya.chatting.repository.ChatRepository;
+import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.notification.service.NotificationService;
+import com.team.buddyya.report.domain.ReportImage;
+import com.team.buddyya.report.repository.ReportImageRepository;
 import com.team.buddyya.report.repository.ReportRepository;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
@@ -19,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.team.buddyya.certification.exception.CertificateExceptionType.STUDENT_ID_CARD_NOT_FOUND;
 import static com.team.buddyya.common.domain.S3DirectoryName.STUDENT_ID_CARD;
 
 @Service
@@ -36,6 +44,10 @@ public class AdminService {
     private final NotificationService notificationService;
     private final StudentIdCardRepository studentIdCardRepository;
     private final ReportRepository reportRepository;
+    private final ReportImageRepository reportImageRepository;
+    private final ChatroomRepository chatroomRepository;
+    private final ChatRepository chatRepository;
+
 
     @Transactional(readOnly = true)
     public StudentIdCardListResponse getStudentIdCards() {

--- a/src/main/java/com/team/buddyya/certification/domain/StudentIdCard.java
+++ b/src/main/java/com/team/buddyya/certification/domain/StudentIdCard.java
@@ -20,8 +20,11 @@ public class StudentIdCard extends CreatedTime {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "image_url", nullable = false)
     private String imageUrl;
+
+    @Column(name = "rejection_reason")
+    private String rejectionReason;
 
     @OneToOne
     @JoinColumn(name = "student_id", nullable = false, unique = true)
@@ -31,10 +34,15 @@ public class StudentIdCard extends CreatedTime {
     public StudentIdCard(String imageUrl, Student student) {
         this.imageUrl = imageUrl;
         this.student = student;
+        this.rejectionReason = null;
     }
 
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    public void updateRejectionReason(String rejectionReason) {
+        this.rejectionReason = rejectionReason;
     }
 
     public void setStudent(Student student) {

--- a/src/main/java/com/team/buddyya/certification/dto/response/StudentIdCardResponse.java
+++ b/src/main/java/com/team/buddyya/certification/dto/response/StudentIdCardResponse.java
@@ -1,8 +1,10 @@
 package com.team.buddyya.certification.dto.response;
 
-public record StudentIdCardResponse(String studentIdCardUrl) {
-
-    public static StudentIdCardResponse from(String studentIdCardUrl) {
-        return new StudentIdCardResponse(studentIdCardUrl);
+public record StudentIdCardResponse(
+        String studentIdCardUrl,
+        String rejectionReason
+) {
+    public static StudentIdCardResponse from(String studentIdCardUrl, String rejectionReason) {
+        return new StudentIdCardResponse(studentIdCardUrl, rejectionReason);
     }
 }

--- a/src/main/java/com/team/buddyya/certification/service/CertificationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/CertificationService.java
@@ -1,11 +1,8 @@
 package com.team.buddyya.certification.service;
 
-import static com.team.buddyya.common.domain.S3DirectoryName.STUDENT_ID_CARD;
-
 import com.team.buddyya.auth.domain.StudentInfo;
 import com.team.buddyya.certification.domain.StudentEmail;
 import com.team.buddyya.certification.domain.StudentIdCard;
-import com.team.buddyya.certification.dto.request.EmailCertificationRequest;
 import com.team.buddyya.certification.dto.request.EmailCodeRequest;
 import com.team.buddyya.certification.dto.request.SendStudentIdCardRequest;
 import com.team.buddyya.certification.dto.response.CertificationResponse;
@@ -18,20 +15,14 @@ import com.team.buddyya.certification.repository.StudentIdCardRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
-import com.team.buddyya.student.service.StudentService;
-
-import java.util.Optional;
-import java.util.Random;
-
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+import static com.team.buddyya.common.domain.S3DirectoryName.STUDENT_ID_CARD;
 
 @Service
 @RequiredArgsConstructor
@@ -107,7 +98,7 @@ public class CertificationService {
     public StudentIdCardResponse getStudentIdCard(StudentInfo studentInfo) {
         StudentIdCard studentIdCard = studentIdCardRepository.findByStudent_Id(studentInfo.id())
                 .orElseThrow(() -> new CertificateException(CertificateExceptionType.STUDENT_ID_CARD_NOT_FOUND));
-        return StudentIdCardResponse.from(studentIdCard.getImageUrl());
+        return StudentIdCardResponse.from(studentIdCard.getImageUrl(), studentIdCard.getRejectionReason());
     }
 
     public void refreshStudentCertification(StudentInfo studentInfo) {

--- a/src/main/java/com/team/buddyya/chatting/repository/ChatRepository.java
+++ b/src/main/java/com/team/buddyya/chatting/repository/ChatRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     Page<Chat> findByChatroom(Chatroom chatroom, Pageable pageable);
+
+    List<Chat> findByChatroom(Chatroom chatroom);
 }

--- a/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
+++ b/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
@@ -7,7 +7,7 @@ public enum FeedExceptionType implements BaseExceptionType {
 
     FEED_NOT_FOUND(4000, HttpStatus.NOT_FOUND, "해당 피드를 찾지 못했습니다."),
     CATEGORY_NOT_FOUND(4000, HttpStatus.NOT_FOUND, "해당 카테고리를 찾지 못했습니다."),
-    NOT_FEED_OWNER(4001, HttpStatus.FORBIDDEN, "해당 피드의 글쓴이기 아닙니다."),
+    NOT_FEED_OWNER(4001, HttpStatus.FORBIDDEN, "해당 피드의 글쓴이가 아닙니다."),
     FEED_ALREADY_LIKED(4002, HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
     FEED_NOT_LIKED(4003, HttpStatus.NOT_FOUND, "좋아요를 누르지 않은 게시글입니다."),
     FEED_ALREADY_BOOKMARKED(4004, HttpStatus.CONFLICT, "이미 북마크한 게시글입니다."),

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -22,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Set;
 
+import static com.team.buddyya.student.domain.Role.ADMIN;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -86,7 +88,7 @@ public class CommentService {
         if (comment.isDeleted()) {
             throw new FeedException(FeedExceptionType.COMMENT_NOT_FOUND);
         }
-        validateCommentOwner(studentInfo.id(), comment);
+        validateCommentOwner(studentInfo, comment);
         comment.updateComment(request.content());
     }
 
@@ -96,7 +98,7 @@ public class CommentService {
         if (comment.isDeleted()) {
             throw new FeedException(FeedExceptionType.COMMENT_NOT_FOUND);
         }
-        validateCommentOwner(studentInfo.id(), comment);
+        validateCommentOwner(studentInfo, comment);
         boolean hasChild = !comment.getChildren().isEmpty();
         if (hasChild) {
             comment.updateIsDeleted(true);
@@ -106,8 +108,8 @@ public class CommentService {
         commentRepository.delete(comment);
     }
 
-    private void validateCommentOwner(Long studentId, Comment comment) {
-        if (!studentId.equals(comment.getStudent().getId())) {
+    private void validateCommentOwner(StudentInfo studentInfo, Comment comment) {
+        if (!studentInfo.id().equals(comment.getStudent().getId()) && !studentInfo.role().equals(ADMIN)) {
             throw new FeedException(FeedExceptionType.NOT_COMMENT_OWNER);
         }
     }

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -27,6 +27,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Set;
 
+import static com.team.buddyya.student.domain.Role.ADMIN;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -143,7 +145,7 @@ public class FeedService {
 
     public void updateFeed(StudentInfo studentInfo, Long feedId, FeedUpdateRequest request) {
         Feed feed = findFeedByFeedId(feedId);
-        validateFeedOwner(studentInfo.id(), feed);
+        validateFeedOwner(studentInfo, feed);
         Category category = categoryService.getCategory(request.category());
         feed.updateFeed(request.title(), request.content(), category);
         updateImages(feed, request.images());
@@ -151,7 +153,7 @@ public class FeedService {
 
     public void deleteFeed(StudentInfo studentInfo, Long feedId) {
         Feed feed = findFeedByFeedId(feedId);
-        validateFeedOwner(studentInfo.id(), feed);
+        validateFeedOwner(studentInfo, feed);
         feedImageService.deleteS3FeedImages(feed);
         feedRepository.delete(feed);
     }
@@ -163,8 +165,8 @@ public class FeedService {
                 .toList();
     }
 
-    private void validateFeedOwner(Long studentId, Feed feed) {
-        if (!studentId.equals(feed.getStudent().getId())) {
+    private void validateFeedOwner(StudentInfo studentInfo, Feed feed) {
+        if (!studentInfo.id().equals(feed.getStudent().getId()) && !studentInfo.role().equals(ADMIN)) {
             throw new FeedException(FeedExceptionType.NOT_FEED_OWNER);
         }
     }

--- a/src/main/java/com/team/buddyya/student/controller/UserController.java
+++ b/src/main/java/com/team/buddyya/student/controller/UserController.java
@@ -5,9 +5,10 @@ import com.team.buddyya.feed.dto.response.feed.FeedListResponse;
 import com.team.buddyya.feed.service.FeedService;
 import com.team.buddyya.student.dto.request.MyPageUpdateRequest;
 import com.team.buddyya.student.dto.request.OnBoardingRequest;
-import com.team.buddyya.student.dto.response.BlockResponse;
-import com.team.buddyya.student.dto.response.UserResponse;
 import com.team.buddyya.student.dto.request.UpdateProfileImageRequest;
+import com.team.buddyya.student.dto.response.BlockResponse;
+import com.team.buddyya.student.dto.response.UserBanStatusResponse;
+import com.team.buddyya.student.dto.response.UserResponse;
 import com.team.buddyya.student.service.OnBoardingService;
 import com.team.buddyya.student.service.StudentService;
 import lombok.RequiredArgsConstructor;
@@ -78,5 +79,10 @@ public class UserController {
                                                       @PathVariable("userId") Long userId) {
         BlockResponse response = studentService.blockStudent(userDetails.getStudentInfo().id(), userId);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/ban-status")
+    public ResponseEntity<UserBanStatusResponse> checkBanStatusOrUpdate(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(studentService.checkBanEndTimeOrUpdate(userDetails.getStudentInfo()));
     }
 }

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -116,6 +116,7 @@ public class Student extends BaseTime {
         this.isCertificated = false;
         this.characterProfileImage = characterProfileImage;
         this.isDeleted = false;
+        this.isBanned = false;
     }
 
     public void updateIsCertificated(boolean isCertificated) {

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -46,7 +46,7 @@ public class Student extends BaseTime {
     @Column(name = "korean", nullable = false)
     private Boolean isKorean;
 
-    @Column(name = "is_deleted", nullable = false)
+    @Column(name = "deleted", nullable = false)
     private Boolean isDeleted;
 
     @OneToOne(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
@@ -94,8 +94,8 @@ public class Student extends BaseTime {
     @OneToMany(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChatroomStudent> chatroomStudents;
 
-    @Column(name = "is_banned", nullable = false)
-    private Boolean isBanned = false;
+    @Column(name = "banned", nullable = false)
+    private Boolean isBanned;
 
     @Column(name = "ban_end_time")
     private LocalDateTime banEndTime;

--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -93,6 +94,12 @@ public class Student extends BaseTime {
     @OneToMany(mappedBy = "student", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChatroomStudent> chatroomStudents;
 
+    @Column(name = "is_banned", nullable = false)
+    private Boolean isBanned = false;
+
+    @Column(name = "ban_end_time")
+    private LocalDateTime banEndTime;
+
     @Builder
     public Student(String name, String phoneNumber, String country, Boolean isKorean, Role role, University university,
                    Gender gender, String characterProfileImage) {
@@ -108,7 +115,7 @@ public class Student extends BaseTime {
         this.interests = new ArrayList<>();
         this.isCertificated = false;
         this.characterProfileImage = characterProfileImage;
-        this.isDeleted=false;
+        this.isDeleted = false;
     }
 
     public void updateIsCertificated(boolean isCertificated) {
@@ -149,5 +156,25 @@ public class Student extends BaseTime {
         this.phoneNumber = "deleted_" + UUID.randomUUID().toString().substring(0, 3);
         this.email = "deleted_" + UUID.randomUUID().toString().substring(0, 4);
         this.name = "UNKNOWN";
+    }
+
+    public boolean checkAndUpdateBanStatus() {
+        if (this.isBanned && this.banEndTime != null) {
+            if (LocalDateTime.now().isAfter(this.banEndTime)) {
+                unban();
+                return false;
+            }
+        }
+        return this.isBanned;
+    }
+
+    public void ban(int days) {
+        this.isBanned = true;
+        this.banEndTime = LocalDateTime.now().plusDays(days);
+    }
+
+    public void unban() {
+        this.isBanned = false;
+        this.banEndTime = null;
     }
 }

--- a/src/main/java/com/team/buddyya/student/dto/response/UserBanStatusResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/UserBanStatusResponse.java
@@ -1,0 +1,13 @@
+package com.team.buddyya.student.dto.response;
+
+import java.time.LocalDateTime;
+
+public record UserBanStatusResponse(
+        boolean isBanned,
+        LocalDateTime banEndTime
+) {
+
+    public static UserBanStatusResponse from(boolean isBanned, LocalDateTime banEndTime) {
+        return new UserBanStatusResponse(isBanned, banEndTime);
+    }
+}

--- a/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
@@ -22,6 +22,7 @@ public record UserResponse(
         List<String> languages,
         List<String> interests,
         String status,
+        Boolean isBanned,
         String accessToken,
         String refreshToken
 ) {
@@ -42,6 +43,7 @@ public record UserResponse(
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
                 null,
+                student.getIsBanned(),
                 null,
                 null
         );
@@ -63,6 +65,7 @@ public record UserResponse(
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
                 null,
+                student.getIsBanned(),
                 null,
                 null
         );
@@ -84,6 +87,7 @@ public record UserResponse(
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
                 null,
+                student.getIsBanned(),
                 accessToken,
                 refreshToken
         );
@@ -105,6 +109,7 @@ public record UserResponse(
                 convertToStringList(student.getLanguages()),
                 convertToStringList(student.getInterests()),
                 status,
+                student.getIsBanned(),
                 accessToken,
                 refreshToken
         );
@@ -126,6 +131,7 @@ public record UserResponse(
                 null,
                 null,
                 status,
+                false,
                 null,
                 null
         );

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -12,14 +12,11 @@ import com.team.buddyya.student.dto.request.MyPageUpdateRequest;
 import com.team.buddyya.student.dto.request.OnBoardingRequest;
 import com.team.buddyya.student.dto.request.UpdateProfileImageRequest;
 import com.team.buddyya.student.dto.response.BlockResponse;
+import com.team.buddyya.student.dto.response.UserBanStatusResponse;
 import com.team.buddyya.student.dto.response.UserResponse;
 import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.*;
-
-import com.team.buddyya.student.repository.BlockRepository;
-import com.team.buddyya.student.repository.StudentRepository;
-import com.team.buddyya.student.repository.UniversityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -163,5 +160,14 @@ public class StudentService {
                 .blockedStudentId(blockerId)
                 .build());
         return BlockResponse.from(BLOCK_SUCCESS_MESSAGE);
+    }
+
+    public UserBanStatusResponse checkBanEndTimeOrUpdate(StudentInfo studentId) {
+        Student student = findStudentService.findByStudentId(studentId.id());
+        boolean isBanned = student.checkAndUpdateBanStatus();
+        if (!isBanned) {
+            studentRepository.save(student);
+        }
+        return new UserBanStatusResponse(isBanned, student.getBanEndTime());
     }
 }

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -165,9 +165,6 @@ public class StudentService {
     public UserBanStatusResponse checkBanEndTimeOrUpdate(StudentInfo studentId) {
         Student student = findStudentService.findByStudentId(studentId.id());
         boolean isBanned = student.checkAndUpdateBanStatus();
-        if (!isBanned) {
-            studentRepository.save(student);
-        }
         return new UserBanStatusResponse(isBanned, student.getBanEndTime());
     }
 }

--- a/src/main/resources/db/migration/V5__Add_student_banned_field.sql
+++ b/src/main/resources/db/migration/V5__Add_student_banned_field.sql
@@ -1,0 +1,12 @@
+ALTER TABLE student
+    ADD ban_end_time datetime NULL;
+
+ALTER TABLE student
+    ADD banned BIT(1) NOT NULL DEFAULT b'0';
+
+ALTER TABLE student_id_card
+    ADD rejection_reason VARCHAR(255) NULL;
+
+ALTER TABLE student
+    CHANGE COLUMN is_deleted deleted BIT(1) NOT NULL DEFAULT b'0';
+


### PR DESCRIPTION
## 📌 관련 이슈
[관리자 제재 기능 및 학생증 승인 / 반려 수정 [#142]](https://github.com/buddy-ya/be/issues/142)
<br><br>

## 🛠️ 작업 내용

- 관리자 제재 기능
- UserResponse에 banned 추가
- 정지된 사용자의 정지 기간이 지나면 banned = false로 유저 정보 수정하는 기능
- 학생증 인증 반려 시 반려 사유 고지
- 게시글, 댓글 강제 삭제

### 1. 관리자 정지 기능
신고된 목록을 확인 후 제재가 필요한 유저의 경우 유저 id와 날짜(1일, 2일, 3일)을 넘겨 `현재 시점으로부터 해당 학생의 정지일을 기록 후 isBanned = true로 변경`합니다.

### 2. 정지 해제 
isBanned = true인 학생은 서비스에 접근하지 못하며 정지가 끝나는 기간을 보여주고, 
isBanned = true일 때 `정지가 끝난 학생이면 isBanned = false로 변경하여 서비스를 이용`할 수 있도록 합니다.

### 3. 학생증(StudentIdCard) 반려 시
학생증 승인 시 해당 학생을 DB와 S3에서 삭제하지만, `반려 시 삭제하지 않고 반려 사유를 사용자에게 보여줍니다`.

### 4. 관리자 게시글, 댓글 강제 삭제
기존 피드 로직에서 유저는 자기가 작성한 피드가 아니면 삭제하지 못합니다. 하지만 `관리자는 삭제가 가능`합니다.
```
private void validateFeedOwner(StudentInfo studentInfo, Feed feed) {
        if (!studentInfo.id().equals(feed.getStudent().getId()) && !studentInfo.role().equals(ADMIN)) {
            throw new FeedException(FeedExceptionType.NOT_FEED_OWNER);
        }
    }
```
이를 `관리자 권한을 검증하여 삭제가 가능하도록 구현`하였습니다.
<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가?
- 유저 제재 정책이 잘 반영됐는가?
<br><br>

## 📎 커밋 범위 링크

<br><br>
