### PR TITLE
refactor: 채팅방 response에 buddyId 추가

### DIFF
--- a/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomDetailResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomDetailResponse.java
@@ -5,9 +5,10 @@ public record ChatroomDetailResponse(
         String name,
         String country,
         String profileImageUrl,
+        Long buddyId,
         Boolean isBuddyExited
 ) {
-    public static ChatroomDetailResponse from(Long roomId, String name, String country, String profileImageUrl, Boolean isBuddyExited) {
-        return new ChatroomDetailResponse(roomId, name, country, profileImageUrl, isBuddyExited);
+    public static ChatroomDetailResponse from(Long roomId, String name, String country, String profileImageUrl, Long buddyId, Boolean isBuddyExited) {
+        return new ChatroomDetailResponse(roomId, name, country, profileImageUrl, buddyId, isBuddyExited);
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomListResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomListResponse.java
@@ -4,10 +4,11 @@ import java.util.List;
 
 public record ChatroomListResponse(
         List<ChatroomResponse> rooms,
-        int totalUnreadCount
+        int totalUnreadCount,
+        boolean hasChatRequest
 ) {
 
-    public static ChatroomListResponse from(List<ChatroomResponse> chatroomResponse, int totalUnreadCount) {
-        return new ChatroomListResponse(chatroomResponse, totalUnreadCount);
+    public static ChatroomListResponse from(List<ChatroomResponse> chatroomResponse, int totalUnreadCount, boolean hasChatRequest) {
+        return new ChatroomListResponse(chatroomResponse, totalUnreadCount, hasChatRequest);
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomResponse.java
+++ b/src/main/java/com/team/buddyya/chatting/dto/response/ChatroomResponse.java
@@ -13,10 +13,11 @@ public record ChatroomResponse(
         String profileImageUrl,
         String lastMessage,
         LocalDateTime lastMessageDate,
+        Long buddyId,
         boolean isBuddyExited
 ) {
 
-    public static ChatroomResponse from(Chatroom chatroom, String name, String country, ChatroomStudent chatroomStudent, String buddyProfileImage, boolean isBuddyLeave) {
-        return new ChatroomResponse(chatroom.getId(), name, country, chatroomStudent.getUnreadCount(), buddyProfileImage, chatroom.getLastMessage(), chatroom.getLastMessageTime(), isBuddyLeave);
+    public static ChatroomResponse from(Chatroom chatroom, String name, String country, ChatroomStudent chatroomStudent, String buddyProfileImage, Long buddyId, boolean isBuddyLeave) {
+        return new ChatroomResponse(chatroom.getId(), name, country, chatroomStudent.getUnreadCount(), buddyProfileImage, chatroom.getLastMessage(), chatroom.getLastMessageTime(), buddyId, isBuddyLeave);
     }
 }

--- a/src/main/java/com/team/buddyya/chatting/repository/ChatRequestRepository.java
+++ b/src/main/java/com/team/buddyya/chatting/repository/ChatRequestRepository.java
@@ -10,6 +10,8 @@ public interface ChatRequestRepository extends JpaRepository<ChatRequest, Long> 
 
     List<ChatRequest> findAllByReceiver(Student receiver);
 
+    boolean existsByReceiver(Student receiver);
+
     boolean existsBySenderAndReceiver(Student sender, Student receiver);
 
     List<ChatRequest> findAllByCreatedDateBefore(LocalDateTime createdDate);

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -188,26 +188,26 @@ public class ChatService {
                 .orElseThrow(() -> new ChatException(ChatExceptionType.USER_NOT_PART_OF_CHATROOM));
         Student buddy = getBuddyFromChatroom(student, chatroom);
         if (buddy == null) {
-            return ChatroomDetailResponse.from(roomId, null, null, null, true);
+            return ChatroomDetailResponse.from(roomId, null, null, null, null, true);
         }
         boolean isBuddyExited = chatroom.getChatroomStudents().stream()
                 .filter(cs -> !cs.getStudent().getId().equals(student.getId()))
                 .anyMatch(ChatroomStudent::getIsExited);
         String buddyProfileImage = getChatroomProfileImage(buddy);
-        return ChatroomDetailResponse.from(roomId, buddy.getName(), buddy.getCountry(), buddyProfileImage, isBuddyExited);
+        return ChatroomDetailResponse.from(roomId, buddy.getName(), buddy.getCountry(), buddyProfileImage, buddy.getId(), isBuddyExited);
     }
 
     private ChatroomResponse createChatroomResponse(ChatroomStudent chatroomStudent) {
         Chatroom chatroom = chatroomStudent.getChatroom();
         Student buddy = getBuddyFromChatroom(chatroomStudent.getStudent(), chatroom);
         if (buddy == null) {
-            return ChatroomResponse.from(chatroom, null, null, chatroomStudent, null, true);
+            return ChatroomResponse.from(chatroom, null, null, chatroomStudent, null, null, true);
         }
         boolean isBuddyExited = chatroom.getChatroomStudents().stream()
                 .filter(cs -> !cs.getStudent().getId().equals(chatroomStudent.getStudent().getId()))
                 .anyMatch(ChatroomStudent::getIsExited);
         String buddyProfileImage = getChatroomProfileImage(buddy);
-        return ChatroomResponse.from(chatroom, buddy.getName(), buddy.getCountry(), chatroomStudent, buddyProfileImage, isBuddyExited);
+        return ChatroomResponse.from(chatroom, buddy.getName(), buddy.getCountry(), chatroomStudent, buddyProfileImage, buddy.getId(), isBuddyExited);
     }
 
     private Student getBuddyFromChatroom(Student student, Chatroom chatroom) {

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -13,6 +13,7 @@ import com.team.buddyya.chatting.dto.response.*;
 import com.team.buddyya.chatting.exception.ChatException;
 import com.team.buddyya.chatting.exception.ChatExceptionType;
 import com.team.buddyya.chatting.repository.ChatRepository;
+import com.team.buddyya.chatting.repository.ChatRequestRepository;
 import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.chatting.repository.ChatroomStudentRepository;
 import com.team.buddyya.common.service.S3UploadService;
@@ -53,6 +54,7 @@ public class ChatService {
     private final S3UploadService s3UploadService;
     private final ChatRepository chatRepository;
     private final ChatroomRepository chatRoomRepository;
+    private final ChatRequestRepository chatRequestRepository;
     private final ChatroomStudentRepository chatroomStudentRepository;
     private final Map<Long, Set<WebSocketSession>> sessionsPerRoom = new ConcurrentHashMap<>();
     private final Map<WebSocketSession, Long> lastPongTimestamps = new ConcurrentHashMap<>();
@@ -176,7 +178,8 @@ public class ChatService {
         int totalUnreadCount = chatroomResponses.stream()
                 .mapToInt(ChatroomResponse::unreadCount)
                 .sum();
-        return ChatroomListResponse.from(chatroomResponses, totalUnreadCount);
+        boolean hasChatRequest = chatRequestRepository.existsByReceiver(student);
+        return ChatroomListResponse.from(chatroomResponses, totalUnreadCount, hasChatRequest);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
@@ -5,6 +5,7 @@ import com.team.buddyya.student.domain.Student;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.team.buddyya.student.domain.UserProfileDefaultImage.getChatroomProfileImage;
 import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
 
 public record UserResponse(
@@ -54,7 +55,7 @@ public record UserResponse(
                 student.getCountry(),
                 student.getUniversity().getUniversityName(),
                 student.getGender().getDisplayName(),
-                student.getProfileImage().getUrl(),
+                getChatroomProfileImage(student),
                 null,
                 null,
                 null,


### PR DESCRIPTION
## 📌 관련 이슈
[채팅방 api에 신고, 차단을 위한 buddyId 추가 [#148]](https://github.com/buddy-ya/be/issues/148)
<br><br>

## 🛠️ 작업 내용
- 채팅방 목록 api response에 buddyId 추가
- 채팅방 목록 api response에 `hasChatRequest`, 채팅 요청이 있는지 반환
- 알림을 통한 채팅방 정보 조회 api response에 buddyId 추가
- 상대 프로필 조회 시, 사진 있다면 사진으로, 사진 없으면 캐릭터로 반환
<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가?
<br><br>

## 📎 커밋 범위 링크

<br><br>
