### PR TITLE
feat: 채팅방 생성 시 생성 메시지 하나 증가 & 읽지 않은 메시지 반환 로직 수정

### DIFF
--- a/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
+++ b/src/main/java/com/team/buddyya/chatting/domain/ChatroomStudent.java
@@ -37,7 +37,7 @@ public class ChatroomStudent extends CreatedTime {
     public ChatroomStudent(Student student, Chatroom chatroom) {
         this.student = student;
         this.chatroom = chatroom;
-        this.unreadCount = 0;
+        this.unreadCount = 1;
         this.isExited = false;
     }
 

--- a/src/main/java/com/team/buddyya/chatting/service/ChatService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatService.java
@@ -175,9 +175,9 @@ public class ChatService {
                 .filter(Objects::nonNull)
                 .sorted((a, b) -> b.lastMessageDate().compareTo(a.lastMessageDate()))
                 .collect(Collectors.toList());
-        int totalUnreadCount = chatroomResponses.stream()
-                .mapToInt(ChatroomResponse::unreadCount)
-                .sum();
+        int totalUnreadCount = (int) chatroomResponses.stream()
+                .filter(chatroomResponse -> chatroomResponse.unreadCount() > 0)
+                .count();
         boolean hasChatRequest = chatRequestRepository.existsByReceiver(student);
         return ChatroomListResponse.from(chatroomResponses, totalUnreadCount, hasChatRequest);
     }


### PR DESCRIPTION
## 📌 관련 이슈
[채팅방 생성 시 생성 메시지 하나 증가 [#153]](https://github.com/buddy-ya/be/issues/153)
<br><br>

## 🛠️ 작업 내용
- 채팅방 생성 시 unreadCount +1 하도록 수정
- 읽지 않은 메시지 반환 로직 수정
<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션에 맞게 작성되었는가?
<br><br>

## 📎 커밋 범위 링크

<br><br>
