### PR TITLE
feat: 로그 아웃 기능 구현

### DIFF
--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -55,6 +55,7 @@ public class PhoneAuthenticationService {
             Student student = optionalStudent.get();
             String accessToken = jwtUtils.createAccessToken(new TokenInfoRequest(student.getId()));
             String refreshToken = student.getAuthToken().getRefreshToken();
+            student.getAvatar().setLoggedOut(false);
             boolean isStudentIdCardRequested = studentIdCardRepository.findByStudent(student).isPresent();
             return UserResponse.from(student, isStudentIdCardRequested, EXISTING_MEMBER, accessToken, refreshToken);
         }

--- a/src/main/java/com/team/buddyya/student/controller/UserController.java
+++ b/src/main/java/com/team/buddyya/student/controller/UserController.java
@@ -79,4 +79,10 @@ public class UserController {
         BlockResponse response = studentService.blockStudent(userDetails.getStudentInfo().id(), userId);
         return ResponseEntity.ok(response);
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        studentService.logout(userDetails.getStudentInfo());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/team/buddyya/student/domain/Avatar.java
+++ b/src/main/java/com/team/buddyya/student/domain/Avatar.java
@@ -45,4 +45,8 @@ public class Avatar extends BaseTime {
         this.student = student;
         student.setAvatar(this);
     }
+
+    public void setLoggedOut(boolean isLoggedOut) {
+        this.isLoggedOut = isLoggedOut;
+    }
 }

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -164,4 +164,12 @@ public class StudentService {
                 .build());
         return BlockResponse.from(BLOCK_SUCCESS_MESSAGE);
     }
+
+    public void logout(StudentInfo studentInfo) {
+        Student student = findStudentService.findByStudentId(studentInfo.id());
+        if (student.getExpoToken() != null) {
+            expoTokenRepository.delete(student.getExpoToken());
+        }
+        student.getAvatar().setLoggedOut(true);
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
[로그아웃 기능](https://github.com/buddy-ya/be/issues/157)[#157]
<br><br>

## 🛠️ 작업 내용
- 로그 아웃 API 구현
1. 엑스포 토큰 삭제
2. `Avatar` 엔티티의 `isLoggedOut` 컬럼 true로 변경

- 재로그인 시 `Avatar` 엔티티의 `isLoggedOut` 컬럼 `false`로 변경

<br><br>

## 🎯 리뷰 포인트
- 로그 아웃 시 ResponseDTO가 필요한가?
-  코드 컨벤션에 어긋난 부분은 없는가?

<br><br>

## 📎 커밋 범위 링크

<br><br>
