### PR TITLE
fix: 피드 조회, 댓글 차단 조회 로직 변경

### DIFF
--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 public record FeedResponse(
         Long id,
         Long userId,
+        String category,
         String name,
         String country,
         String title,
@@ -33,6 +34,7 @@ public record FeedResponse(
         return new FeedResponse(
                 feed.getId(),
                 feed.getStudent().getId(),
+                feed.getCategory().getName(),
                 feed.getStudent().getName(),
                 feed.getStudent().getCountry(),
                 feed.getTitle(),

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -51,7 +51,11 @@ public class CommentService {
         Set<Long> blockedStudentIds = blockRepository.findBlockedStudentIdByBlockerId(studentInfo.id());
         List<Comment> comments = feed.getComments().stream()
                 .filter(comment -> comment.getParent() == null)
-                .filter(comment -> !blockedStudentIds.contains(comment.getStudent().getId()))
+                .filter(comment -> {
+                    boolean isBlocked = blockedStudentIds.contains(comment.getStudent().getId());
+                    boolean hasChildren = !comment.getChildren().isEmpty();
+                    return hasChildren || !isBlocked;
+                })
                 .toList();
         return comments.stream()
                 .map(comment -> CommentResponse.from(comment, feedId, studentInfo.id(), commentLikeRepository, blockedStudentIds))

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -88,7 +88,8 @@ public class FeedService {
     public FeedListResponse getMyFeed(StudentInfo studentInfo, Pageable pageable) {
         Pageable customPageable = PageRequest.of(
                 pageable.getPageNumber(),
-                pageable.getPageSize()
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdDate")
         );
         Student student = findStudentByStudentId(studentInfo.id());
         Page<Feed> feeds = feedRepository.findAllByStudent(student, customPageable);


### PR DESCRIPTION
## 📌 관련 이슈
[피드 조회, 카테고리 변경 및 댓글 차단 로직 수정 #164](https://github.com/buddy-ya/be/issues/164)
<br><br>

## 🛠️ 작업 내용
- 부모 댓글이 차단된 경우에도 자식 댓글이 있는 부모 댓글은 조회되도록 필터링 로직 수정
- 피드 Response에 카테고리 추가
- 나의 글, 최신순으로 조회 반환
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
