### PR TITLE
fix: 자기가 쓴 글에 댓글 달 때 스스로에게 알림 오는 오류 수정

### DIFF
--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -112,4 +112,8 @@ public class Feed extends BaseTime {
     public void uploadFeedImages(List<FeedImage> images) {
         this.images = images;
     }
+
+    public boolean isMine(Long studentId) {
+        return this.student.getId().equals(studentId);
+    }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -113,7 +113,7 @@ public class Feed extends BaseTime {
         this.images = images;
     }
 
-    public boolean isMine(Long studentId) {
+    public boolean isFeedOwner(Long studentId) {
         return this.student.getId().equals(studentId);
     }
 }

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -76,7 +76,7 @@ public class CommentService {
                 .parent(parent)
                 .build();
         commentRepository.save(comment);
-        if(!feed.isMine(studentInfo.id())) {
+        if(!feed.isFeedOwner(studentInfo.id())) {
             notificationService.sendCommentNotification(feed, request.content());
         }
     }

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -76,7 +76,9 @@ public class CommentService {
                 .parent(parent)
                 .build();
         commentRepository.save(comment);
-        notificationService.sendCommentNotification(feed, request.content());
+        if(!feed.isMine(studentInfo.id())) {
+            notificationService.sendCommentNotification(feed, request.content());
+        }
     }
 
     public void updateComment(StudentInfo studentInfo, Long feedId, Long commentId,


### PR DESCRIPTION
## 📌 관련 이슈
[자기가 쓴 글에 댓글 달 때 스스로에게 알림 오는 오류](https://github.com/buddy-ya/be/issues/166)[#166]

<br><br>

## 🛠️ 작업 내용
- feed 엔티티에 studentId를 주면 자신의 쓴글의 유무를 반환하는 메서드 `isMine` 추가
- `CommentService`에서 `isMine`이 아닌 즉 자신의 피드가 아닐 때만 피드의 주인에게 알림 가도록 변경

<br><br>

## 🎯 리뷰 포인트
- 컨벤션에 어긋난 부분은 없나요?

<br><br>

## 📎 커밋 범위 링크

<br><br>
