### PR TITLE
fix: 자기 피드 대댓글 알림 오류 수정

### DIFF
--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -65,8 +65,8 @@ public class CommentService {
     public void createComment(StudentInfo studentInfo, Long feedId, CommentCreateRequest request) {
         Student student = findStudentService.findByStudentId(studentInfo.id());
         Feed feed = findFeedByFeedId(feedId);
-        Comment parent = null;
         boolean isFeedOwner = feed.isFeedOwner(studentInfo.id());
+        Comment parent = null;
         if (request.parentId() != null) {
             parent = findCommentByCommentId(request.parentId());
             if (parent.getParent() != null) {

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -66,12 +66,15 @@ public class CommentService {
         Student student = findStudentService.findByStudentId(studentInfo.id());
         Feed feed = findFeedByFeedId(feedId);
         Comment parent = null;
+        boolean isFeedOwner = feed.isFeedOwner(studentInfo.id());
         if (request.parentId() != null) {
             parent = findCommentByCommentId(request.parentId());
             if (parent.getParent() != null) {
                 throw new FeedException(FeedExceptionType.COMMENT_DEPTH_LIMIT);
             }
-            notificationService.sendCommentReplyNotification(feed, parent, request.content());
+            if(!isFeedOwner) {
+                notificationService.sendCommentReplyNotification(feed, parent, request.content());
+            }
         }
         Comment comment = Comment.builder()
                 .student(student)
@@ -80,7 +83,7 @@ public class CommentService {
                 .parent(parent)
                 .build();
         commentRepository.save(comment);
-        if(!feed.isFeedOwner(studentInfo.id())) {
+        if(!isFeedOwner) {
             notificationService.sendCommentNotification(feed, request.content());
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
[자기 피드 대댓글 알림 오류](https://github.com/buddy-ya/be/issues/168)[#168]

<br><br>

## 🛠️ 작업 내용
- `isFeedOwner`을 메서드 호출 최초에 조회 후 if 문에 사용

- 자기 게시물에서 대댓글을 작성했을 때 알림이 오는 오류가 발생하여,
만약 자기 게시물이 아닐 경우에만 알림을 보내는 로직으로 수정

<br><br>

## 🎯 리뷰 포인트
- 컨벤션에 어긋난 부분은 없나요?

<br><br>

## 📎 커밋 범위 링크

<br><br>
