### PR TITLE
fix: 대댓글의 주인이 자신의 댓글에 대댓글을 달 때 알림 오류 수정

### DIFF
--- a/src/main/java/com/team/buddyya/feed/domain/Comment.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Comment.java
@@ -91,6 +91,10 @@ public class Comment extends BaseTime {
         this.likeCount--;
     }
 
+    public boolean isParent(Long studentId) {
+        return this.student.getId().equals(studentId);
+    }
+
     @PrePersist
     private void prePersist() {
         feed.increaseCommentCount();

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -71,10 +71,11 @@ public class CommentService {
         Comment parent = null;
         if (request.parentId() != null) {
             parent = findCommentByCommentId(request.parentId());
+            boolean isParent = parent.isParent(studentInfo.id());
             if (parent.getParent() != null) {
                 throw new FeedException(FeedExceptionType.COMMENT_DEPTH_LIMIT);
             }
-            if(!isFeedOwner) {
+            if(!isFeedOwner && !isParent) {
                 notificationService.sendCommentReplyNotification(feed, parent, request.content());
             }
         }


### PR DESCRIPTION
## 📌 관련 이슈
[대댓글의 주인이 자신의 댓글에 대댓글을 달 때 알림 오류](https://github.com/buddy-ya/be/issues/175)[#175]

<br><br>

## 🛠️ 작업 내용
- 자신이 대댓글의 최상위 주인인지 확인하는 `isParent` 메서드 `Comment` 엔티티에 추가
- 대댓글 알림을 보내기전에 댓글을 작성하는 유저가 `isParent`가 아닌지 확인하여 아닐 시에만 알림을 보내는
로직으로 수정

-> 결국 대댓글 알림은 `1. 피드의 주인이 아닌 `, `2. 대댓글의 주인이 아닌 `유저가 대댓글을 작성했을 때 대댓글의 주인에게
알림이 간다

<br><br>

## 🎯 리뷰 포인트
- 컨벤션에 어긋난 부분은 없나요?

<br><br>

## 📎 커밋 범위 링크

<br><br>
