### PR TITLE
refactor: 대학교 이메일 인증 외국인일 경우에 영문 이메일 전송

### DIFF
--- a/src/main/java/com/team/buddyya/certification/service/EmailSendService.java
+++ b/src/main/java/com/team/buddyya/certification/service/EmailSendService.java
@@ -25,6 +25,8 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class EmailSendService {
 
+    private static final String KOREAN_SUBJECT = "[버디야] 대학교 인증을 위한 인증번호를 안내 드립니다.";
+    private static final String ENGLISH_SUBJECT = "[Buddyya] University Email Verification Code";
     private static final int AUTH_CODE_MAX_RANGE = 10_000;
 
     private final JavaMailSender javaMailSender;
@@ -40,7 +42,7 @@ public class EmailSendService {
         String generatedCode = generateRandomNumber();
         try {
             String emailContent = getEmailTemplate(student.getIsKorean(), generatedCode);
-            MimeMessage message = createMail(emailRequest.email(), emailContent);
+            MimeMessage message = createMail(student.getIsKorean(), emailRequest.email(), emailContent);
             javaMailSender.send(message);
             return generatedCode;
         } catch (IOException | MessagingException | MailException e) {
@@ -64,11 +66,11 @@ public class EmailSendService {
         return content.replace("{{code}}", code);
     }
 
-    public MimeMessage createMail(String mail, String emailContent) throws MessagingException {
+    public MimeMessage createMail(boolean isKorean, String mail, String emailContent) throws MessagingException {
         MimeMessage message = javaMailSender.createMimeMessage();
         message.setFrom(senderEmail);
         message.setRecipients(MimeMessage.RecipientType.TO, mail);
-        message.setSubject("[Buddyya] University Email Verification Code");
+        message.setSubject(isKorean ? KOREAN_SUBJECT : ENGLISH_SUBJECT);
         message.setText(emailContent, "UTF-8", "html");
         return message;
     }

--- a/src/main/resources/templates/email_english.html
+++ b/src/main/resources/templates/email_english.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>University Email Verification</title>
+</head>
+<body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px;">
+<h1 style="text-align: center; color: #333;">University Email Verification</h1>
+<p style="font-size: 16px; color: #555;">Hello, <b>Dear User</b></p>
+<p style="font-size: 16px; color: #555;">
+    Please copy or enter the verification code below to complete your university email verification.
+</p>
+<div style="text-align: center; margin: 20px 0;">
+        <span style="display: inline-block; font-size: 24px; color: #0073e6; font-weight: bold; padding: 10px 20px; border: 1px dashed #0073e6; border-radius: 5px;">
+            {{code}}
+        </span>
+</div>
+<p style="font-size: 16px; color: #555; text-align: center;">Thank you.</p>
+</body>
+</html>

--- a/src/main/resources/templates/email_korean.html
+++ b/src/main/resources/templates/email_korean.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>대학교 이메일 인증</title>
+</head>
+<body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px;">
+<h1 style="text-align: center; color: #333;">대학교 이메일 인증 안내</h1>
+<p style="font-size: 16px; color: #555;">안녕하세요, <b>유저님</b></p>
+<p style="font-size: 16px; color: #555;">
+    아래 발급된 이메일 인증번호를 복사하거나 직접 입력하여 인증을 완료해주세요.
+</p>
+<div style="text-align: center; margin: 20px 0;">
+        <span style="display: inline-block; font-size: 24px; color: #0073e6; font-weight: bold; padding: 10px 20px; border: 1px dashed #0073e6; border-radius: 5px;">
+            {{code}}
+        </span>
+</div>
+<p style="font-size: 16px; color: #555; text-align: center;">감사합니다.</p>
+</body>
+</html>


### PR DESCRIPTION
## 📌 관련 이슈
[대학교 이메일 인증 외국인일 경우에 영문 이메일 전송](https://github.com/buddy-ya/be/issues/177)[#177]

<br><br>

## 🛠️ 작업 내용
- 자바/스프링 코드 사이에 있는 html 파일 별도의 파일로 분리
- 학생의 `isKorean` 필드를 확인 후 외국인 이면 영문 이메일 전송 한국인이면 한국어 이메일 전송 로직 구현

<img src="https://github.com/user-attachments/assets/a6bebea3-0d2d-432a-b9fe-6d08d7aee6a7" width="300">
<img src="https://github.com/user-attachments/assets/2331ee96-c336-44a9-a4c6-9508c143a251" width="300">

<br><br>

## 🎯 리뷰 포인트
-  컨벤션에 어긋난 부분이 있나요?
- 이메일의 내용은 괜찮은가요?


<br><br>

## 📎 커밋 범위 링크

<br><br>
