### PR TITLE
deploy: 채팅 이미지 전송 오류 해결을 위해 /node로 시작하는 엔드포인트 security 검사 안하게 설정

### DIFF
--- a/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
+++ b/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, "/users").permitAll()
                         .requestMatchers("/ws/**", "/ws/chat/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/phone-auth/**", "/users/universities",
+                        .requestMatchers("/phone-auth/**", "/users/universities", "/node/**",
                                 "/auth/reissue", "/auth/test").permitAll()
                         .requestMatchers("/auth/fail", "/admin/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/users", "/auth/success", "/certification/**", "/feeds/**", "/chatrooms/**",


### PR DESCRIPTION
## 📌 관련 이슈
[노드 관련 엔드포인트 security 해제](https://github.com/buddy-ya/be/issues/180)[#180]

<br><br>

## 🛠️ 작업 내용
- 채팅 이미지 전송 오류 해결을 위해 /node로 시작하는 엔드포인트 security 검사 안하게 설정

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
