### PR TITLE
refactor:  SecurityConfig에서 이미지 전송 오류 수정을 위해 변경했던 node관련 설정 제거

### DIFF
--- a/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
+++ b/src/main/java/com/team/buddyya/common/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, "/users").permitAll()
                         .requestMatchers("/ws/**", "/ws/chat/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/phone-auth/**", "/users/universities", "/node/**",
+                        .requestMatchers("/phone-auth/**", "/users/universities",
                                 "/auth/reissue", "/auth/test").permitAll()
                         .requestMatchers("/auth/fail", "/admin/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/users", "/auth/success", "/certification/**", "/feeds/**", "/chatrooms/**",


### PR DESCRIPTION
## 📌 관련 이슈
[채팅 이미지 전송 오류 수정을 위해 변경했던 사항 원상 복귀](https://github.com/buddy-ya/be/issues/187)[#187]

<br><br>

## 🛠️ 작업 내용
- `SecurityConfig`에서 이미지 전송 오류 수정을 위해 변경했던 node관련 설정 제거

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
