### PR TITLE
feat: 휴대폰 인증 번호 전송 횟수 제한

### DIFF
--- a/src/main/java/com/team/buddyya/certification/controller/PhoneAuthenticationController.java
+++ b/src/main/java/com/team/buddyya/certification/controller/PhoneAuthenticationController.java
@@ -37,7 +37,7 @@ public class PhoneAuthenticationController {
 
     @PostMapping("/verify-code")
     public ResponseEntity<UserResponse> verifyCode(@RequestBody VerifyCodeRequest request) {
-        phoneAuthenticationService.verifyCode(request.phoneNumber(), request.code());
+        phoneAuthenticationService.verifyCode(request.phoneNumber(), request.code(), request.phoneInfo());
         UserResponse response = phoneAuthenticationService.checkMembership(request.phoneNumber());
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/team/buddyya/certification/controller/PhoneAuthenticationController.java
+++ b/src/main/java/com/team/buddyya/certification/controller/PhoneAuthenticationController.java
@@ -1,5 +1,6 @@
 package com.team.buddyya.certification.controller;
 
+import com.team.buddyya.certification.dto.request.SavePhoneInfoRequest;
 import com.team.buddyya.certification.dto.request.SendCodeRequest;
 import com.team.buddyya.certification.dto.request.VerifyCodeRequest;
 import com.team.buddyya.certification.dto.response.SendCodeResponse;
@@ -21,17 +22,23 @@ public class PhoneAuthenticationController {
     private final PhoneAuthenticationService phoneAuthenticationService;
     private final MessageSendService messageSendService;
 
+    @PostMapping("/save-phone-info")
+    public ResponseEntity<Void> savePhoneInfo(@RequestBody SavePhoneInfoRequest request){
+        phoneAuthenticationService.savePhoneInfo(request);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/send-code")
-    public ResponseEntity<SendCodeResponse> sendOne(@RequestBody SendCodeRequest sendCodeRequest) {
-        String generatedCode = messageSendService.sendMessage(sendCodeRequest.phoneNumber());
-        SendCodeResponse response = phoneAuthenticationService.saveCode(sendCodeRequest.phoneNumber(), generatedCode);
+    public ResponseEntity<SendCodeResponse> sendOne(@RequestBody SendCodeRequest request) {
+        String generatedCode = messageSendService.sendMessage(request);
+        SendCodeResponse response = phoneAuthenticationService.saveCode(request.phoneNumber(), generatedCode);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/verify-code")
-    public ResponseEntity<UserResponse> verifyCode(@RequestBody VerifyCodeRequest verifyCodeRequest) {
-        phoneAuthenticationService.verifyCode(verifyCodeRequest.phoneNumber(), verifyCodeRequest.code());
-        UserResponse response = phoneAuthenticationService.checkMembership(verifyCodeRequest.phoneNumber());
+    public ResponseEntity<UserResponse> verifyCode(@RequestBody VerifyCodeRequest request) {
+        phoneAuthenticationService.verifyCode(request.phoneNumber(), request.code());
+        UserResponse response = phoneAuthenticationService.checkMembership(request.phoneNumber());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/team/buddyya/certification/domain/PhoneInfo.java
+++ b/src/main/java/com/team/buddyya/certification/domain/PhoneInfo.java
@@ -14,6 +14,7 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class PhoneInfo {
 
+    private static final Integer INITIAL_AUTHENTICATION_COUNT = 0;
     private static final int AUTHENTICATION_MAX_RANGE = 10;
 
     @Id
@@ -29,12 +30,18 @@ public class PhoneInfo {
     @Builder
     public PhoneInfo(String deviceId, int sendMessageCount) {
         this.deviceId = deviceId;
-        this.sendMessageCount = sendMessageCount;
+        this.sendMessageCount = INITIAL_AUTHENTICATION_COUNT;
+    }
+
+    public void resetMessageSendCount() {
+        this.sendMessageCount = INITIAL_AUTHENTICATION_COUNT;
     }
 
     public void increaseMessageSendCount() {
         this.sendMessageCount++;
     }
 
-    public boolean isMaxSendMessageCount(){ return this.sendMessageCount> AUTHENTICATION_MAX_RANGE; }
+    public boolean isMaxSendMessageCount() {
+        return this.sendMessageCount > AUTHENTICATION_MAX_RANGE;
+    }
 }

--- a/src/main/java/com/team/buddyya/certification/domain/PhoneInfo.java
+++ b/src/main/java/com/team/buddyya/certification/domain/PhoneInfo.java
@@ -1,0 +1,40 @@
+package com.team.buddyya.certification.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "phone_info")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class PhoneInfo {
+
+    private static final int AUTHENTICATION_MAX_RANGE = 10;
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String deviceId;
+
+    @Column(name = "send_Message_count", nullable = false)
+    private int sendMessageCount;
+
+    @Builder
+    public PhoneInfo(String deviceId, int sendMessageCount) {
+        this.deviceId = deviceId;
+        this.sendMessageCount = sendMessageCount;
+    }
+
+    public void increaseMessageSendCount() {
+        this.sendMessageCount++;
+    }
+
+    public boolean isMaxSendMessageCount(){ return this.sendMessageCount> AUTHENTICATION_MAX_RANGE; }
+}

--- a/src/main/java/com/team/buddyya/certification/dto/request/SavePhoneInfoRequest.java
+++ b/src/main/java/com/team/buddyya/certification/dto/request/SavePhoneInfoRequest.java
@@ -1,0 +1,4 @@
+package com.team.buddyya.certification.dto.request;
+
+public record SavePhoneInfoRequest (String phoneInfo) {
+}

--- a/src/main/java/com/team/buddyya/certification/dto/request/SendCodeRequest.java
+++ b/src/main/java/com/team/buddyya/certification/dto/request/SendCodeRequest.java
@@ -1,4 +1,4 @@
 package com.team.buddyya.certification.dto.request;
 
-public record SendCodeRequest(String phoneNumber) {
+public record SendCodeRequest(String phoneNumber, String phoneInfo) {
 }

--- a/src/main/java/com/team/buddyya/certification/dto/request/VerifyCodeRequest.java
+++ b/src/main/java/com/team/buddyya/certification/dto/request/VerifyCodeRequest.java
@@ -1,5 +1,6 @@
 package com.team.buddyya.certification.dto.request;
 public record VerifyCodeRequest(
         String phoneNumber,
-        String code) {
+        String code,
+        String phoneInfo) {
 }

--- a/src/main/java/com/team/buddyya/certification/exception/PhoneAuthenticationExceptionType.java
+++ b/src/main/java/com/team/buddyya/certification/exception/PhoneAuthenticationExceptionType.java
@@ -6,8 +6,10 @@ import org.springframework.http.HttpStatus;
 public enum PhoneAuthenticationExceptionType implements BaseExceptionType {
 
     SMS_SEND_FAILED(1000, HttpStatus.UNAUTHORIZED, "Failed to send SMS."),
-    PHONE_NOT_FOUND(1003, HttpStatus.NOT_FOUND, "Matching phone number not found."),
-    CODE_MISMATCH(1000, HttpStatus.UNAUTHORIZED, "Authentication code does not match.");
+    PHONE_NOT_FOUND(1000, HttpStatus.NOT_FOUND, "Matching phone number not found."),
+    PHONE_INFO_NOT_FOUND(1000, HttpStatus.NOT_FOUND, "Matching phone Info not found."),
+    CODE_MISMATCH(1000, HttpStatus.UNAUTHORIZED, "Authentication code does not match."),
+    MAX_SMS_SEND_COUNT(1004, HttpStatus.TOO_MANY_REQUESTS, "Too many SMS sent.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/certification/repository/PhoneInfoRepository.java
+++ b/src/main/java/com/team/buddyya/certification/repository/PhoneInfoRepository.java
@@ -1,0 +1,13 @@
+package com.team.buddyya.certification.repository;
+
+import com.team.buddyya.certification.domain.PhoneInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PhoneInfoRepository extends JpaRepository<PhoneInfo, Long> {
+
+    Optional<PhoneInfo> findPhoneInfoByDeviceId(String deviceId);
+}

--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -2,10 +2,13 @@ package com.team.buddyya.certification.service;
 
 import com.team.buddyya.auth.dto.request.TokenInfoRequest;
 import com.team.buddyya.auth.jwt.JwtUtils;
+import com.team.buddyya.certification.domain.PhoneInfo;
 import com.team.buddyya.certification.domain.RegisteredPhone;
+import com.team.buddyya.certification.dto.request.SavePhoneInfoRequest;
 import com.team.buddyya.certification.dto.response.SendCodeResponse;
 import com.team.buddyya.certification.exception.PhoneAuthenticationException;
 import com.team.buddyya.certification.exception.PhoneAuthenticationExceptionType;
+import com.team.buddyya.certification.repository.PhoneInfoRepository;
 import com.team.buddyya.certification.repository.RegisteredPhoneRepository;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
 import com.team.buddyya.student.domain.Student;
@@ -25,14 +28,23 @@ public class PhoneAuthenticationService {
 
     private static final String EXISTING_MEMBER = "EXISTING_MEMBER";
     private static final String NEW_MEMBER = "NEW_MEMBER";
+    private static final Integer INITIAL_AUTHENTICATION_COUNT = 0;
 
     private final RegisteredPhoneRepository registeredPhoneRepository;
     private final StudentRepository studentRepository;
     private final StudentIdCardRepository studentIdCardRepository;
+    private final PhoneInfoRepository phoneInfoRepository;
     private final JwtUtils jwtUtils;
 
     @Value("${test.phone.number.prefix}")
     private String testPhoneNumberPrefix;
+
+    public void savePhoneInfo(SavePhoneInfoRequest request){
+        phoneInfoRepository.save(PhoneInfo.builder()
+                .deviceId(request.phoneInfo())
+                .sendMessageCount(INITIAL_AUTHENTICATION_COUNT)
+                .build());
+    }
 
     public SendCodeResponse saveCode(String phoneNumber, String generatedCode) {
         RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(phoneNumber)


### PR DESCRIPTION
## 📌 관련 이슈
[휴대폰 인증 횟수 제한](https://github.com/buddy-ya/be/issues/129)[#129]

<br><br>

## 🛠️ 작업 내용
: 인증 번호 전송 횟수를 제한하기 위해서는 휴대폰 번호로 제한을 두는게 아니라
각 디바이스의 고유 번호를 저장하여 해당 기기의 전송 횟수를 세아려 제한하였습니다.

- 디바이스의 고유번호와 전송 횟수를 저장하는 `PhoneInfo` 엔티티 작성
- 전송을 할 때마다 전송 횟수를 증가시켜, 최대 전송 횟수를 초과할 경우 예외 처리 
- 인증에 성공하였다면, 전송 횟수가 누적되지 않도록 0으로 초기화  

<br><br>

## 🎯 리뷰 포인트

- 코드 컨벤션에 어긋난 부분은 없나요?
- 현재는 전송 횟수를 초과하면 저희가 풀어주지 않는 이상 인증 요청을 보내지 못하도록 하였는데
적절한 방안인지 한번 생각해봐야할 것 같습니다. 

### 프론트와 논의하여할 부분 🤔 
- 프론트와 통신 시 기기를 식별하기 위해서 디바이스 아이디를 매 API 요청마다
받아야하는데 매번 아이디를 조회할 수 있는지 알 필요가 있습니다.

<br><br>

## 📎 커밋 범위 링크

<br><br>
