### PR TITLE
fix: Long은 wrapper 클래스이므로 equals로 비교하고 불필요한 로그 삭제

### DIFF
--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -111,8 +111,6 @@ public class StudentService {
     @Transactional(readOnly = true)
     public UserResponse getUserInfo(StudentInfo studentInfo, Long userId) {
         Student student = findStudentService.findByStudentId(userId);
-        boolean isUser = studentInfo.id().equals(userId);
-        System.out.println("userId : " + userId +" studentInfo.Id : " + studentInfo.id()+ "isUser : "+ isUser);
         if (!studentInfo.id().equals(userId)) {
             return UserResponse.from(student);
         }


### PR DESCRIPTION
## 📌 관련 이슈
[wrapper 타입 비교에서 equal 사용](https://github.com/buddy-ya/be/issues/197)[#197]

<br><br>

## 🛠️ 작업 내용
유저 정보 조회 시, URI로 전달된 유저 ID와 토큰에 저장된 유저 ID를 비교하는 과정에서
`== 연산자`를 사용하여 예상치 못한 결과가 발생했습니다.
이는 ID가 Long과 같은 Wrapper 클래스이기 때문에, 객체 주소를 비교하는 `== 연산자`가 아닌,
실제 값을 비교하는 `equals()`를 사용해야 합니다.
따라서, `== 연산자`를 `equals()`로 변경하여 올바르게 값을 비교하도록 수정하였습니다.

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
