### PR TITLE
refactor: 탈퇴 시 핸드폰번호와 이메일을 임의값 겹칠 것을 대비하여 UUID 범위를 증가

### DIFF
--- a/src/main/java/com/team/buddyya/student/domain/Student.java
+++ b/src/main/java/com/team/buddyya/student/domain/Student.java
@@ -154,8 +154,8 @@ public class Student extends BaseTime {
     public void markAsDeleted() {
         this.isDeleted = true;
         this.isCertificated = false;
-        this.phoneNumber = "deleted_" + UUID.randomUUID().toString().substring(0, 3);
-        this.email = "deleted_" + UUID.randomUUID().toString().substring(0, 4);
+        this.phoneNumber = "d_" + UUID.randomUUID().toString().substring(0, 9);
+        this.email = "d_" + UUID.randomUUID().toString().substring(0, 9);
         this.name = "UNKNOWN";
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
[회원 탈퇴시 email, phonenumber를 다른 형식의 랜덤값으로 수정](https://github.com/buddy-ya/be/issues/198)[#198]

<br><br>

## 🛠️ 작업 내용
- 현재는 탈퇴 시 아래와 같이 임의 값으로 핸드폰 번호와 이메일 컬럼을 초기화하는데
```
this.phoneNumber = "deleted_" + UUID.randomUUID().toString().substring(0, 3);
this.email = "deleted_" + UUID.randomUUID().toString().substring(0, 4);
```
핸드폰 번호, 이메일 각각 고유한 문자열 조합은 4,096가지, 65,536가지로 탈퇴한 유저가 많아질 수록 
겹칠 확률이 매우 높으므로 UUID의 범위를 늘려 겹칠 확률을 줄이고자 합니다.

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
