### PR TITLE
feat: 프론트와 논의된 api 수정

### DIFF
--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -7,6 +7,7 @@ import com.team.buddyya.admin.dto.response.AdminReportResponse;
 import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.admin.service.AdminService;
+import com.team.buddyya.report.domain.ReportType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,9 +31,15 @@ public class AdminController {
         return ResponseEntity.ok(adminService.verifyStudentIdCard(request));
     }
 
-    @GetMapping("/reports")
-    public ResponseEntity<List<AdminReportResponse>> getReports() {
-        return ResponseEntity.ok(adminService.getAllReports());
+    @GetMapping("/reports/{type}")
+    public ResponseEntity<List<AdminReportResponse>> getReportsByType(@PathVariable("type") ReportType type) {
+        return ResponseEntity.ok(adminService.getReportsByType(type));
+    }
+
+    @DeleteMapping("/reports/{reportId}")
+    public ResponseEntity<Void> deleteReport(@PathVariable("reportId") Long reportId) {
+        adminService.deleteReport(reportId);
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/ban/{studentId}")

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -23,17 +23,20 @@ public class AdminController {
 
     @GetMapping("/student-id-cards")
     public ResponseEntity<List<StudentIdCardResponse>> getStudentIdCards() {
-        return ResponseEntity.ok(adminService.getStudentIdCards());
+        List<StudentIdCardResponse> response = adminService.getStudentIdCards();
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/student-id-cards/verify")
     public ResponseEntity<StudentVerificationResponse> verifyStudentIdCard(@RequestBody StudentVerificationRequest request) {
-        return ResponseEntity.ok(adminService.verifyStudentIdCard(request));
+        StudentVerificationResponse response = adminService.verifyStudentIdCard(request);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/reports/{type}")
     public ResponseEntity<List<AdminReportResponse>> getReportsByType(@PathVariable("type") ReportType type) {
-        return ResponseEntity.ok(adminService.getReportsByType(type));
+        List<AdminReportResponse> response = adminService.getReportsByType(type);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/reports/{reportId}")

--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -4,7 +4,7 @@ import com.team.buddyya.admin.dto.request.BanRequest;
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
 import com.team.buddyya.admin.dto.response.AdminChatMessageResponse;
 import com.team.buddyya.admin.dto.response.AdminReportResponse;
-import com.team.buddyya.admin.dto.response.StudentIdCardListResponse;
+import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
 import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class AdminController {
     private final AdminService adminService;
 
     @GetMapping("/student-id-cards")
-    public ResponseEntity<StudentIdCardListResponse> getStudentIdCards() {
+    public ResponseEntity<List<StudentIdCardResponse>> getStudentIdCards() {
         return ResponseEntity.ok(adminService.getStudentIdCards());
     }
 

--- a/src/main/java/com/team/buddyya/admin/dto/request/StudentVerificationRequest.java
+++ b/src/main/java/com/team/buddyya/admin/dto/request/StudentVerificationRequest.java
@@ -3,7 +3,6 @@ package com.team.buddyya.admin.dto.request;
 public record StudentVerificationRequest(
         Long id,
         boolean isApproved,
-        String rejectionReason,
-        String imageUrl
+        String rejectionReason
 ) {
 }

--- a/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/StudentIdCardResponse.java
@@ -5,14 +5,16 @@ import com.team.buddyya.certification.domain.StudentIdCard;
 public record StudentIdCardResponse(
         Long id,
         Long userId,
-        String imageUrl
+        String imageUrl,
+        String university
 ) {
 
     public static StudentIdCardResponse from(StudentIdCard studentIdCard) {
         return new StudentIdCardResponse(
                 studentIdCard.getId(),
                 studentIdCard.getStudent().getId(),
-                studentIdCard.getImageUrl()
+                studentIdCard.getImageUrl(),
+                studentIdCard.getStudent().getUniversity().getUniversityName()
         );
     }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -1,7 +1,10 @@
 package com.team.buddyya.admin.service;
 
 import com.team.buddyya.admin.dto.request.StudentVerificationRequest;
-import com.team.buddyya.admin.dto.response.*;
+import com.team.buddyya.admin.dto.response.AdminChatMessageResponse;
+import com.team.buddyya.admin.dto.response.AdminReportResponse;
+import com.team.buddyya.admin.dto.response.StudentIdCardResponse;
+import com.team.buddyya.admin.dto.response.StudentVerificationResponse;
 import com.team.buddyya.certification.domain.StudentIdCard;
 import com.team.buddyya.certification.exception.CertificateException;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
@@ -50,11 +53,10 @@ public class AdminService {
 
 
     @Transactional(readOnly = true)
-    public StudentIdCardListResponse getStudentIdCards() {
-        List<StudentIdCardResponse> studentIdCards = studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
+    public List<StudentIdCardResponse> getStudentIdCards() {
+        return studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
                 .map(StudentIdCardResponse::from)
                 .collect(Collectors.toList());
-        return StudentIdCardListResponse.from(studentIdCards);
     }
 
     public StudentVerificationResponse verifyStudentIdCard(StudentVerificationRequest request) {

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -58,7 +58,6 @@ public class AdminService {
     private final ChatroomRepository chatroomRepository;
     private final ChatRepository chatRepository;
 
-
     @Transactional(readOnly = true)
     public List<StudentIdCardResponse> getStudentIdCards() {
         return studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -100,7 +100,6 @@ public class AdminService {
         reportRepository.delete(report);
     }
 
-
     private List<String> getImageUrlsByReportId(Long reportId) {
         return reportImageRepository.findByReportId(reportId).stream()
                 .map(ReportImage::getImageUrl)

--- a/src/main/java/com/team/buddyya/report/exception/ReportException.java
+++ b/src/main/java/com/team/buddyya/report/exception/ReportException.java
@@ -1,0 +1,18 @@
+package com.team.buddyya.report.exception;
+
+import com.team.buddyya.common.exception.BaseException;
+import com.team.buddyya.common.exception.BaseExceptionType;
+
+public class ReportException extends BaseException {
+
+    private final ReportExceptionType reportExceptionType;
+
+    public ReportException(ReportExceptionType reportExceptionType) {
+        this.reportExceptionType = reportExceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return reportExceptionType;
+    }
+}

--- a/src/main/java/com/team/buddyya/report/exception/ReportExceptionType.java
+++ b/src/main/java/com/team/buddyya/report/exception/ReportExceptionType.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ReportExceptionType implements BaseExceptionType {
 
-    REPORT_NOT_FOUND(4000, HttpStatus.NOT_FOUND, "Report not found.");
+    REPORT_NOT_FOUND(8000, HttpStatus.NOT_FOUND, "Report not found.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/report/exception/ReportExceptionType.java
+++ b/src/main/java/com/team/buddyya/report/exception/ReportExceptionType.java
@@ -1,0 +1,34 @@
+package com.team.buddyya.report.exception;
+
+import com.team.buddyya.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum ReportExceptionType implements BaseExceptionType {
+
+    REPORT_NOT_FOUND(4000, HttpStatus.NOT_FOUND, "Report not found.");
+
+    private final int errorCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    ReportExceptionType(int errorCode, HttpStatus httpStatus, String errorMessage) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public int errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/team/buddyya/report/repository/ReportRepository.java
+++ b/src/main/java/com/team/buddyya/report/repository/ReportRepository.java
@@ -1,7 +1,12 @@
 package com.team.buddyya.report.repository;
 
 import com.team.buddyya.report.domain.Report;
+import com.team.buddyya.report.domain.ReportType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    List<Report> findByType(ReportType type);
 }


### PR DESCRIPTION
## 📌 관련 이슈
[프론트와 논의 후 api 수정 [#191]](https://github.com/buddy-ya/be/issues/191)
<br><br>

## 🛠️ 작업 내용
프론트와 논의된 api에 대하여 수정합니다.

**1. 학생증 목록** 
- studentIdCards 바로 list로 반환
- 반환 목록에 학교(university) 추가

**2. 학생증 승인 반려**
- 기존에 id를 studentId로 사용하였지만 studentIdCards로 사용
- imageUrl 삭제를 위해 프론트에게 imageUrl을 받지 않고 student_id_card를 db에서 url 조회하여 s3에 삭제 요청

**3. 신고 목록 조회에서 카테고리별 분리**
- FEED, COMMENT, CHATROOM으로 분리하여 각각 조회

**4. 관리자 신고 목록 삭제 api 추가**
- 확인된 신고 목록은 남겨두지 않고 관리자가 삭제

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션이 잘 지켜졌는가?
<br><br>

## 📎 커밋 범위 링크

<br><br>
