### PR TITLE
refactor: 매칭 요청시 ALL or MALE or FEMALE로 성별을 받는 것으로 수정

### DIFF
--- a/src/main/java/com/team/buddyya/match/domain/GenderType.java
+++ b/src/main/java/com/team/buddyya/match/domain/GenderType.java
@@ -9,8 +9,9 @@ import java.util.Arrays;
 @Getter
 public enum GenderType {
 
-    SAME_GENDER("SAME"),
-    ALL_GENDER("ALL");
+    MALE("MALE"),
+    FEMALE("FEMALE"),
+    ALL("ALL");
 
     private final String displayName;
 
@@ -20,7 +21,7 @@ public enum GenderType {
 
     public static GenderType fromValue(String value) {
         return Arrays.stream(GenderType.values())
-                .filter(type -> type.displayName.equals(value))
+                .filter(type -> type.displayName.equalsIgnoreCase(value))
                 .findFirst()
                 .orElseThrow(() -> new MatchException(MatchExceptionType.INVALID_MATCH_TYPE));
     }

--- a/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
+++ b/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
@@ -6,7 +6,6 @@ import com.team.buddyya.chatting.exception.ChatException;
 import com.team.buddyya.chatting.exception.ChatExceptionType;
 import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.chatting.repository.ChatroomStudentRepository;
-import com.team.buddyya.chatting.service.ChatRequestService;
 import com.team.buddyya.chatting.service.ChatService;
 import com.team.buddyya.match.domain.*;
 import com.team.buddyya.match.dto.request.MatchCreateRequest;
@@ -34,7 +33,6 @@ public class BasicMatchService implements MatchService {
     private final MatchRequestRepository matchRequestRepository;
     private final MatchedHistoryRepository matchedHistoryRepository;
     private final FindStudentService findStudentService;
-    private final ChatRequestService chatRequestService;
     private final ChatService chatService;
     private final ChatroomRepository chatroomRepository;
     private final ChatroomStudentRepository chatroomStudentRepository;
@@ -132,13 +130,10 @@ public class BasicMatchService implements MatchService {
 
     private boolean isGenderMatch(GenderType matchRequestGenderType, GenderType requestedGenderType,
                                   Gender matchRequestGender, Gender requestedGender) {
-        if (matchRequestGenderType == GenderType.SAME_GENDER && requestedGenderType == GenderType.SAME_GENDER) {
-            return matchRequestGender == requestedGender;
+        if (matchRequestGenderType == GenderType.ALL && requestedGenderType == GenderType.ALL) {
+            return true;
         }
-        if (matchRequestGenderType == GenderType.SAME_GENDER || requestedGenderType == GenderType.SAME_GENDER) {
-            return matchRequestGender == requestedGender;
-        }
-        return true;
+        return matchRequestGender == requestedGender;
     }
 
     private MatchResponse processMatchSuccess(Student student, UniversityType universityType, GenderType genderType, MatchRequest matchRequest) {


### PR DESCRIPTION
## 📌 관련 이슈
[매칭 요청시 ALL 혹은 직접 적인 성별을 받는 것으로 수정](https://github.com/buddy-ya/be/issues/209)[#209]

<br><br>

## 🛠️ 작업 내용
- genderType을 `ALL`, `SAME`에서 `ALL`, `MALE`, `FEMALE`로 수정
- 성별 매칭 로직(`isGenderMatch`) 수정
-> 둘다 원하는 성별이 `ALL`이면 둘의 성별에 상관없이 통과, but 둘 중에 하나라도 `ALL`이 아니면 둘의 성별이 같도록
```
private boolean isGenderMatch(GenderType matchRequestGenderType, GenderType requestedGenderType,
                              Gender matchRequestGender, Gender requestedGender) {

    if (matchRequestGenderType == GenderType.ALL && requestedGenderType == GenderType.ALL) {
        return true;
    }

    return matchRequestGender == requestedGender;
}
```

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
