### PR TITLE
feat: 유저의 포인트 기록 조회 기능 구현

### DIFF
--- a/src/main/java/com/team/buddyya/point/controller/PointController.java
+++ b/src/main/java/com/team/buddyya/point/controller/PointController.java
@@ -1,0 +1,25 @@
+package com.team.buddyya.point.controller;
+
+import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.point.dto.PointListResponse;
+import com.team.buddyya.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/points")
+@RequiredArgsConstructor
+public class PointController {
+
+    private final PointService pointService;
+
+    @GetMapping
+    public ResponseEntity<PointListResponse> getPoints(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        PointListResponse response = pointService.getPoints(userDetails.getStudentInfo());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/team/buddyya/point/domain/PointChangeType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointChangeType.java
@@ -1,0 +1,17 @@
+package com.team.buddyya.point.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum PointChangeType {
+
+    EARN("earn"),
+    DEDUCT("deduct"),
+    NONE("none");
+
+    private final String displayName;
+
+    PointChangeType(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -9,19 +9,21 @@ import java.util.Arrays;
 @Getter
 public enum PointType {
 
-    SIGNUP("signup", +100),
-    UNIVERSITY_AUTH("university_auth",1),
-    CHAT_REQUEST("chat_request", -1),
-    MATCH_REQUEST("match_request", -1),
-    CANCEL_MATCH_REQUEST("cancel_match_request", +1),
-    NO_POINT_CHANGE("no_point_change",0);
+    SIGNUP("signup", +100, PointChangeType.EARN),
+    UNIVERSITY_AUTH("university_auth", 1, PointChangeType.EARN),
+    CHAT_REQUEST("chat_request", -1, PointChangeType.DEDUCT),
+    MATCH_REQUEST("match_request", -1, PointChangeType.DEDUCT),
+    CANCEL_MATCH_REQUEST("cancel_match_request", +1, PointChangeType.EARN),
+    NO_POINT_CHANGE("no_point_change", 0, PointChangeType.NONE);
 
     private final String displayName;
     private final int pointChange;
+    private final PointChangeType changeType;
 
-    PointType(String displayName, int pointChange) {
+    PointType(String displayName, int pointChange, PointChangeType changeType) {
         this.displayName = displayName;
         this.pointChange = pointChange;
+        this.changeType = changeType;
     }
 
     public static PointType fromValue(String displayName) {

--- a/src/main/java/com/team/buddyya/point/dto/PointListResponse.java
+++ b/src/main/java/com/team/buddyya/point/dto/PointListResponse.java
@@ -1,0 +1,18 @@
+package com.team.buddyya.point.dto;
+
+import com.team.buddyya.point.domain.Point;
+
+import java.util.List;
+
+public record PointListResponse(
+        List<PointResponse> points,
+        int currentPoint
+) {
+
+    public static PointListResponse from(Point point, List<PointResponse> points) {
+        return new PointListResponse(
+                points,
+                point.getCurrentPoint()
+        );
+    }
+}

--- a/src/main/java/com/team/buddyya/point/dto/PointResponse.java
+++ b/src/main/java/com/team/buddyya/point/dto/PointResponse.java
@@ -1,0 +1,26 @@
+package com.team.buddyya.point.dto;
+
+import com.team.buddyya.point.domain.PointStatus;
+import com.team.buddyya.point.domain.PointType;
+
+import java.time.LocalDateTime;
+
+public record PointResponse(
+        Long id,
+        String pointType,
+        String pointChangeType,
+        int pointChange,
+        LocalDateTime createdDate
+) {
+
+    public static PointResponse from(PointStatus pointStatus) {
+        PointType pointType = pointStatus.getPointType();
+        return new PointResponse(
+                pointStatus.getId(),
+                pointType.getDisplayName(),
+                pointType.getChangeType().getDisplayName(),
+                pointType.getPointChange(),
+                pointStatus.getCreatedDate()
+        );
+    }
+}

--- a/src/main/java/com/team/buddyya/point/repository/PointStatusRepository.java
+++ b/src/main/java/com/team/buddyya/point/repository/PointStatusRepository.java
@@ -1,7 +1,12 @@
 package com.team.buddyya.point.repository;
 
+import com.team.buddyya.point.domain.Point;
 import com.team.buddyya.point.domain.PointStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PointStatusRepository extends JpaRepository<PointStatus, Long> {
+
+    List<PointStatus> findAllByPoint(Point point);
 }

--- a/src/main/java/com/team/buddyya/point/service/PointService.java
+++ b/src/main/java/com/team/buddyya/point/service/PointService.java
@@ -1,14 +1,21 @@
 package com.team.buddyya.point.service;
 
+import com.team.buddyya.auth.domain.StudentInfo;
 import com.team.buddyya.point.domain.Point;
 import com.team.buddyya.point.domain.PointStatus;
 import com.team.buddyya.point.domain.PointType;
+import com.team.buddyya.point.dto.PointListResponse;
+import com.team.buddyya.point.dto.PointResponse;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.point.repository.PointRepository;
 import com.team.buddyya.point.repository.PointStatusRepository;
+import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +24,8 @@ public class PointService {
 
     private final PointRepository pointRepository;
     private final PointStatusRepository pointStatusRepository;
+    private final FindStudentService findStudentService;
+    private final FindPointService findPointService;
 
     public Point createPoint(Student student) {
         Point point = Point.builder()
@@ -31,5 +40,15 @@ public class PointService {
                 .build();
         pointStatusRepository.save(signUpPointStatus);
         return point;
+    }
+
+    public PointListResponse getPoints(StudentInfo studentInfo){
+        Student student = findStudentService.findByStudentId(studentInfo.id());
+        Point point = findPointService.findByStudent(student);
+        List<PointStatus> pointStatuses = pointStatusRepository.findAllByPoint(point);
+        List<PointResponse> pointResponses = pointStatuses.stream()
+                .map(PointResponse::from)
+                .collect(Collectors.toList());
+        return PointListResponse.from(point, pointResponses);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
[유저의 포인트 기록 조회 기능](https://github.com/buddy-ya/be/issues/213)[#213]

<br><br>

## 🛠️ 작업 내용
- 유저의 포인트 기록 조회 기능 구현

`PointListResponse`
1. 현재 포인트 값
2. List< PointResponse >

`PointResponse`
1. id : pointStatus 아이디
2. pointType: 포인트 유형
3. pointChangeType: 포인트 변화 유형 (적립, 차감, 변화없음)
4. pointChange: 포인트 변화값
5. LocalDateTime createdDate: 포인트 변화가 일어난 시기

`응답값 예시`
```
{
    "points": [
        {
            "id": 1,
            "pointType": "signup",
            "pointChangeType": "earn",
            "pointChange": 100,
            "createdDate": "2025-03-24T21:03:24"
        },
        {
            "id": 14,
            "pointType": "match_request",
            "pointChangeType": "deduct",
            "pointChange": -1,
            "createdDate": "2025-03-24T21:13:08"
        },
        {
            "id": 15,
            "pointType": "cancel_match_request",
            "pointChangeType": "earn",
            "pointChange": 1,
            "createdDate": "2025-03-24T21:13:32"
        }
    ],
    "currentPoint": 100
}
```

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션에 어긋난 부분이 있나요?

<br><br>

## 📎 커밋 범위 링크

<br><br>
