### PR TITLE
refactor: 회원 탈퇴 시 매칭 요청을 삭제하고 탈퇴하거나 차단한 유저와 매칭되지 않도록 수정

### DIFF
--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -6,6 +6,7 @@ import com.team.buddyya.certification.repository.RegisteredPhoneRepository;
 import com.team.buddyya.certification.repository.StudentEmailRepository;
 import com.team.buddyya.certification.repository.StudentIdCardRepository;
 import com.team.buddyya.common.service.S3UploadService;
+import com.team.buddyya.match.repository.MatchRequestRepository;
 import com.team.buddyya.notification.repository.ExpoTokenRepository;
 import com.team.buddyya.point.domain.Point;
 import com.team.buddyya.point.service.FindPointService;
@@ -44,6 +45,7 @@ public class StudentService {
     private final RegisteredPhoneRepository registeredPhoneRepository;
     private final StudentEmailRepository studentEmailRepository;
     private final FindPointService findPointService;
+    private final MatchRequestRepository matchRequestRepository;
 
     private static final String BLOCK_SUCCESS_MESSAGE = "차단이 성공적으로 완료되었습니다.";
 
@@ -139,6 +141,8 @@ public class StudentService {
         }
         profileImageService.setDefaultProfileImage(student);
         registeredPhoneRepository.deleteByPhoneNumber(student.getPhoneNumber());
+        matchRequestRepository.findByStudentId(student.getId())
+                .ifPresent(matchRequest -> matchRequestRepository.deleteByStudent(student));
         studentEmailRepository.deleteByEmail(student.getEmail());
         student.markAsDeleted();
     }


### PR DESCRIPTION
## 📌 관련 이슈
[회원 탈퇴시 매칭 요청을 삭제하고 탈퇴하거나 차단한 유저와 매칭되지 않도록 수정](https://github.com/buddy-ya/be/issues/224)[#224]

<br><br>

## 🛠️ 작업 내용
- 회원 탈퇴 시 유저의 매칭 요청을 삭제
- 매칭 과정에서 차단한/된 사용자와는 매칭되지 않도록 검증 추가

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션에 어긋난 부분은 없나요?

<br><br>

## 📎 커밋 범위 링크

<br><br>
