### PR TITLE
feat: 피드 대학별 조회 반영

### DIFF
--- a/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedCreateRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedCreateRequest.java
@@ -1,5 +1,6 @@
 package com.team.buddyya.feed.dto.request.feed;
 
+import com.team.buddyya.student.domain.University;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -7,6 +8,7 @@ import java.util.List;
 public record FeedCreateRequest(
         String title,
         String content,
+        String university,
         String category,
         List<MultipartFile> images
 ) {

--- a/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedCreateRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedCreateRequest.java
@@ -1,9 +1,7 @@
 package com.team.buddyya.feed.dto.request.feed;
 
-import com.team.buddyya.student.domain.University;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public record FeedCreateRequest(
         String title,

--- a/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedListRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedListRequest.java
@@ -5,8 +5,4 @@ public record FeedListRequest(
         String category,
         String keyword
 ) {
-
-    public static FeedListRequest of(String category, String keyword) {
-        return new FeedListRequest(university, category, keyword);
-    }
 }

--- a/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedListRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedListRequest.java
@@ -1,11 +1,12 @@
 package com.team.buddyya.feed.dto.request.feed;
 
 public record FeedListRequest(
+        String university,
         String category,
         String keyword
 ) {
 
     public static FeedListRequest of(String category, String keyword) {
-        return new FeedListRequest(category, keyword);
+        return new FeedListRequest(university, category, keyword);
     }
 }

--- a/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedUpdateRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedUpdateRequest.java
@@ -7,7 +7,6 @@ import java.util.List;
 public record FeedUpdateRequest(
         String title,
         String content,
-        String university,
         String category,
         List<MultipartFile> images
 ) {

--- a/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedUpdateRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedUpdateRequest.java
@@ -7,8 +7,8 @@ import java.util.List;
 public record FeedUpdateRequest(
         String title,
         String content,
+        String university,
         String category,
         List<MultipartFile> images
 ) {
-
 }

--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
@@ -25,6 +25,7 @@ public record CommentResponse(
         boolean isCommentOwner,
         boolean isBlocked,
         boolean isProfileImageUpload,
+        boolean isStudentDeleted,
         List<CommentResponse> replies
 ) {
 
@@ -54,6 +55,7 @@ public record CommentResponse(
                 isCommentOwner,
                 isBlocked,
                 isProfileImageUpload,
+                comment.getStudent().getIsDeleted(),
                 replies
         );
     }

--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -25,6 +25,7 @@ public record FeedResponse(
         boolean isLiked,
         boolean isBookmarked,
         boolean isProfileImageUpload,
+        boolean isStudentDeleted,
         LocalDateTime createdDate
 ) {
 
@@ -51,6 +52,7 @@ public record FeedResponse(
                 userAction.isLiked(),
                 userAction.isBookmarked(),
                 isProfileImageUpload,
+                feed.getStudent().getIsDeleted(),
                 feed.getCreatedDate()
         );
     }

--- a/src/main/java/com/team/buddyya/feed/repository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/repository/FeedRepository.java
@@ -1,7 +1,9 @@
 package com.team.buddyya.feed.repository;
 
+import com.team.buddyya.feed.domain.Category;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.domain.University;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,15 +13,17 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
-    Page<Feed> findAllByCategoryName(String category, Pageable pageable);
+    Page<Feed> findAllByUniversityAndCategory(University university, Category category, Pageable pageable);
 
     Page<Feed> findAllByStudent(Student student, Pageable pageable);
 
-    List<Feed> findAllByStudent(Student student);
-
-    Page<Feed> findByTitleContainingOrContentContaining(String titleQuery, String contentQuery, Pageable pageable);
+    Page<Feed> findByTitleContainingOrContentContainingAndUniversityIn(
+            String titleQuery,
+            String contentQuery,
+            List<University> universities,
+            Pageable pageable
+    );
 
     Page<Feed> findByLikeCountGreaterThanEqual(int likeCount, Pageable pageable);
 
-    void deleteAllByStudent(Student student);
 }

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -13,7 +13,11 @@ import com.team.buddyya.feed.repository.BookmarkRepository;
 import com.team.buddyya.feed.repository.FeedLikeRepository;
 import com.team.buddyya.feed.repository.FeedRepository;
 import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.domain.University;
+import com.team.buddyya.student.exception.StudentException;
+import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.BlockRepository;
+import com.team.buddyya.student.repository.UniversityRepository;
 import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -43,6 +47,7 @@ public class FeedService {
     private final BookmarkRepository bookmarkRepository;
     private final FeedImageService feedImageService;
     private final BlockRepository blockRepository;
+    private final UniversityRepository universityRepository;
 
     @Transactional(readOnly = true)
     protected Feed findFeedByFeedId(Long feedId) {
@@ -132,13 +137,15 @@ public class FeedService {
 
     public void createFeed(StudentInfo studentInfo, FeedCreateRequest request) {
         Category category = categoryService.getCategory(request.category());
+        University university = universityRepository.findByUniversityName(request.university())
+                .orElseThrow(() -> new StudentException(StudentExceptionType.UNIVERSITY_NOT_FOUND));
         Student student = findStudentByStudentId(studentInfo.id());
         Feed feed = Feed.builder()
                 .title(request.title())
                 .content(request.content())
                 .student(student)
                 .category(category)
-                .university(student.getUniversity())
+                .university(university)
                 .build();
         feedRepository.save(feed);
         uploadImages(feed, request.images());


### PR DESCRIPTION
## 📌 관련 이슈
[피드 학교별 구분 및 카테고리화 #229](https://github.com/buddy-ya/be/issues/229)
<br><br>

## 🛠️ 작업 내용
- 기존 피드 목록 조회 시 사용자의 소속 대학과 전역(예: "all") 대학에 해당하는 피드만 조회하도록 변경했습니다.
- "all" 대학의 경우는 `오픈 캠퍼스`와 같이 여러 대학이 참여할 수있는 게시판이며, 현재 별도의 카테고리는 없으나 확장성을 위해 `free` 카테고리에 일단 저장할 생각입니다. (대학 스크립트 변경)
- 피드 및 댓글 작성자가 회원탈퇴 했을 경우에, DTO 필드에 두어 
클라이언트에서 탈퇴한 유저와 인터랙션을 못하게 하였습니다.

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션에 어긋나는 부분은 없는가?
<br><br>

## 📎 커밋 범위 링크

<br><br>
