### PR TITLE
fix: 1004 에러 코드가 중복되었으므로 SMS 인증 초과 예외를 1005번 에러코드로 수정

### DIFF
--- a/src/main/java/com/team/buddyya/certification/exception/PhoneAuthenticationExceptionType.java
+++ b/src/main/java/com/team/buddyya/certification/exception/PhoneAuthenticationExceptionType.java
@@ -9,7 +9,7 @@ public enum PhoneAuthenticationExceptionType implements BaseExceptionType {
     PHONE_NOT_FOUND(1000, HttpStatus.NOT_FOUND, "Matching phone number not found."),
     PHONE_INFO_NOT_FOUND(1000, HttpStatus.NOT_FOUND, "Matching phone Info not found."),
     CODE_MISMATCH(1000, HttpStatus.UNAUTHORIZED, "Authentication code does not match."),
-    MAX_SMS_SEND_COUNT(1004, HttpStatus.TOO_MANY_REQUESTS, "Too many SMS sent.");
+    MAX_SMS_SEND_COUNT(1005, HttpStatus.TOO_MANY_REQUESTS, "Too many SMS sent.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📌 관련 이슈
[1004 에러 코드 중복](https://github.com/buddy-ya/be/issues/236)[#236]

<br><br>

## 🛠️ 작업 내용
- 1004 에러 코드가 중복되었으므로 SMS 인증 초과 예외를 1005번 에러코드로 수정

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
