### PR TITLE
fix: 핸드폰 인증번호 검증 시 udId를 nullable하게 받도록 수정

### DIFF
--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -63,9 +63,11 @@ public class PhoneAuthenticationService {
         if (!inputCode.equals(registeredPhone.getAuthenticationCode())) {
             throw new PhoneAuthenticationException(PhoneAuthenticationExceptionType.CODE_MISMATCH);
         }
-        PhoneInfo phoneInfo = phoneInfoRepository.findPhoneInfoByUdId(udId)
-                .orElseThrow(()-> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_INFO_NOT_FOUND));
-        phoneInfo.resetMessageSendCount();
+        if (udId != null) {
+            PhoneInfo phoneInfo = phoneInfoRepository.findPhoneInfoByUdId(udId)
+                    .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_INFO_NOT_FOUND));
+            phoneInfo.resetMessageSendCount();
+        }
     }
 
     public UserResponse checkMembership(String phoneNumber) {

--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -63,11 +63,7 @@ public class PhoneAuthenticationService {
         if (!inputCode.equals(registeredPhone.getAuthenticationCode())) {
             throw new PhoneAuthenticationException(PhoneAuthenticationExceptionType.CODE_MISMATCH);
         }
-        if (udId != null) {
-            PhoneInfo phoneInfo = phoneInfoRepository.findPhoneInfoByUdId(udId)
-                    .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_INFO_NOT_FOUND));
-            phoneInfo.resetMessageSendCount();
-        }
+        resetMessageCountIfExists(udId);
     }
 
     public UserResponse checkMembership(String phoneNumber) {
@@ -105,5 +101,14 @@ public class PhoneAuthenticationService {
             return new AdminAccountResponse(true);
         }
         return new AdminAccountResponse(false);
+    }
+
+    private void resetMessageCountIfExists(String udId) {
+        if (udId == null) {
+            return;
+        }
+        PhoneInfo phoneInfo = phoneInfoRepository.findPhoneInfoByUdId(udId)
+                .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_INFO_NOT_FOUND));
+        phoneInfo.resetMessageSendCount();
     }
 }

--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -53,7 +53,6 @@ public class PhoneAuthenticationService {
         return new SendCodeResponse(phoneNumber);
     }
 
-    @Transactional(readOnly = true)
     public void verifyCode(String phoneNumber, String inputCode, String udId) {
         RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(phoneNumber)
                 .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));


### PR DESCRIPTION
## 📌 관련 이슈
[핸드폰 인증번호 검증 시 udId를 nullable하게 받도록 수정](https://github.com/buddy-ya/be/issues/241)[#241]
<br><br>

## 🛠️ 작업 내용
```
private void resetMessageCountIfExists(String udId) {
        if (udId == null) {
            return;
        }
        PhoneInfo phoneInfo = phoneInfoRepository.findPhoneInfoByUdId(udId)
                .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_INFO_NOT_FOUND));
        phoneInfo.resetMessageSendCount();
    }
```
유저가 휴대폰 인증에 성공했다면 인증 코드 전송 횟수를 0으로 초기화 해주는데,
테스트 유저나 웹에서는 udid가 null로 들어올 수 있으므로 null일 경우에는 해당 작업을 하지 않는 것으로
로직을 수정하였습니다.

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
