### PR TITLE
feat: 피드 탭 정보 DTO에 제공

### DIFF
--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 public record FeedResponse(
         Long id,
         Long userId,
+        String universityTab,
         String category,
         String name,
         String country,
@@ -35,6 +36,7 @@ public record FeedResponse(
         return new FeedResponse(
                 feed.getId(),
                 feed.getStudent().getId(),
+                feed.getUniversity().getUniversityName(),
                 feed.getCategory().getName(),
                 feed.getStudent().getName(),
                 feed.getStudent().getCountry(),


### PR DESCRIPTION
## 📌 관련 이슈
[피드 학교별 구분 및 카테고리화 #229](https://github.com/buddy-ya/be/issues/229)
<br><br>

## 🛠️ 작업 내용
- 대학 별 조회를 나타내는 `universityTab`을 `FeedResponse`에 필드로 두어, 프론트에서 캐싱 처리가 가능하도록 처리했습니다.

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션에 어긋나는 부분은 없는가?
<br><br>

## 📎 커밋 범위 링크

<br><br>
