### PR TITLE
feat: 기획안 기반으로 PointType별 포인트 변경값 설정

### DIFF
--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -9,12 +9,12 @@ import java.util.Arrays;
 @Getter
 public enum PointType {
 
-    SIGNUP("signup", +100, PointChangeType.EARN),
+    SIGNUP("signup", 100, PointChangeType.EARN),
     UNIVERSITY_AUTH("university_auth", 1, PointChangeType.EARN),
-    INVITATION_EVENT("invitation_event", 10, PointChangeType.EARN),
-    CHAT_REQUEST("chat_request", -1, PointChangeType.DEDUCT),
-    MATCH_REQUEST("match_request", -1, PointChangeType.DEDUCT),
-    CANCEL_MATCH_REQUEST("cancel_match_request", +1, PointChangeType.EARN),
+    INVITATION_EVENT("invitation_event", 50, PointChangeType.EARN),
+    CHAT_REQUEST("chat_request", -15, PointChangeType.DEDUCT),
+    MATCH_REQUEST("match_request", -35, PointChangeType.DEDUCT),
+    CANCEL_MATCH_REQUEST("cancel_match_request", 35, PointChangeType.EARN),
     NO_POINT_CHANGE("no_point_change", 0, PointChangeType.NONE);
 
     private final String displayName;


### PR DESCRIPTION
## 📌 관련 이슈
[feat: 기획안 기반으로 PointType별 포인트 변경값 설정](https://github.com/buddy-ya/be/issues/249)[#249]

<br><br>

## 🛠️ 작업 내용
- 회원가입 `+100`
- 매칭 `-35`
- 피드를 통한 채팅 요청 `-15`
- 친구초대 `+50`

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
