### PR TITLE
feat: 응답 없는 매칭 사용자를 관리자에게 신고하고 포인트 환급 기능

### DIFF
--- a/src/main/java/com/team/buddyya/admin/controller/AdminController.java
+++ b/src/main/java/com/team/buddyya/admin/controller/AdminController.java
@@ -64,4 +64,12 @@ public class AdminController {
         List<AdminChatMessageResponse> response = adminService.getAllChatMessages(roomId);
         return ResponseEntity.ok(response);
     }
+
+    @PostMapping("/refund/{roomId}/{reportUserId}")
+    public ResponseEntity<Void> refundPointsToUser(
+            @PathVariable("roomId") Long roomId,
+            @PathVariable("reportUserId") Long reportUserId) {
+        adminService.refundPointsToUser(roomId, reportUserId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -18,11 +18,10 @@ import com.team.buddyya.chatting.repository.ChatRepository;
 import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.notification.service.NotificationService;
-import com.team.buddyya.point.domain.Point;
-import com.team.buddyya.point.domain.PointStatus;
 import com.team.buddyya.point.domain.PointType;
 import com.team.buddyya.point.repository.PointStatusRepository;
 import com.team.buddyya.point.service.FindPointService;
+import com.team.buddyya.point.service.UpdatePointService;
 import com.team.buddyya.report.domain.Report;
 import com.team.buddyya.report.domain.ReportImage;
 import com.team.buddyya.report.domain.ReportType;
@@ -59,6 +58,7 @@ public class AdminService {
     private final S3UploadService s3UploadService;
     private final NotificationService notificationService;
     private final FindPointService findPointService;
+    private final UpdatePointService updatePointService;
     private final StudentIdCardRepository studentIdCardRepository;
     private final ReportRepository reportRepository;
     private final ReportImageRepository reportImageRepository;
@@ -145,19 +145,7 @@ public class AdminService {
                 .orElseThrow(() -> new ChatException(ChatExceptionType.CHATROOM_NOT_FOUND));
         if (chatroom.getType().equals(ChatroomType.MATCHING)) {
             Student reportUser = findStudentService.findByStudentId(reportUserId);
-            refundPoint(reportUser, PointType.CHATROOM_NO_RESPONSE_REFUND);
+            updatePointService.updatePoint(reportUser, PointType.CHATROOM_NO_RESPONSE_REFUND);
         }
-    }
-
-    private void refundPoint(Student student, PointType pointType) {
-        Point point = findPointService.findByStudent(student);
-        int pointChange = pointType.getPointChange();
-        point.updatePoint(pointChange);
-        PointStatus pointStatus = PointStatus.builder()
-                .point(point)
-                .pointType(pointType)
-                .changedPoint(pointChange)
-                .build();
-        pointStatusRepository.save(pointStatus);
     }
 }

--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -15,7 +15,8 @@ public enum PointType {
     CHAT_REQUEST("chat_request", -15, PointChangeType.DEDUCT),
     MATCH_REQUEST("match_request", -35, PointChangeType.DEDUCT),
     CANCEL_MATCH_REQUEST("cancel_match_request", 35, PointChangeType.EARN),
-    NO_POINT_CHANGE("no_point_change", 0, PointChangeType.NONE);
+    NO_POINT_CHANGE("no_point_change", 0, PointChangeType.NONE),
+    CHATROOM_NO_RESPONSE_REFUND("chatroom_no_response_refund", 35, PointChangeType.EARN);
 
     private final String displayName;
     private final int pointChange;

--- a/src/main/java/com/team/buddyya/report/domain/ReportType.java
+++ b/src/main/java/com/team/buddyya/report/domain/ReportType.java
@@ -3,5 +3,6 @@ package com.team.buddyya.report.domain;
 public enum ReportType {
     FEED,
     COMMENT,
-    CHATROOM
+    CHATROOM,
+    CHATROOM_NO_RESPONSE
 }

--- a/src/main/java/com/team/buddyya/student/domain/CharacterProfileImage.java
+++ b/src/main/java/com/team/buddyya/student/domain/CharacterProfileImage.java
@@ -15,8 +15,7 @@ public enum CharacterProfileImage {
     CHARACTER_PROFILE_IMAGE_5("image5", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image5.png"),
     CHARACTER_PROFILE_IMAGE_6("image6", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image6.png"),
     CHARACTER_PROFILE_IMAGE_7("image7", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image7.png"),
-    CHARACTER_PROFILE_IMAGE_8("image8", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image8.png"),
-    CHARACTER_PROFILE_IMAGE_9("image9", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image9.png");
+    CHARACTER_PROFILE_IMAGE_8("image8", "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image8.png");
 
     private final String key;
     private final String url;


### PR DESCRIPTION
## 📌 관련 이슈
[응답 없는 매칭 사용자를 관리자에게 신고하고 포인트 환급 기능 [#254]](https://github.com/buddy-ya/be/issues/254)
<br><br>

## 🛠️ 작업 내용
- 신고 type에 CHATROOM_NO_RESPONSE 추가
- PointType에 `CHATROOM_NO_RESPONSE_REFUND("chatroom_no_response_refund", 35, PointChangeType.EARN);` 추가
- roomId와 reportUserId를 통해 관리자가 해당 사용자에게 포인트를 환급하는 기능 추가
- 캐릭터 프로필 9번 삭제
<br><br>

## 🎯 리뷰 포인트
- 컨벤션이 잘 지켜졌는가?
- point 정책에 맞게 설계되어 있는가?
<br><br>

## 📎 커밋 범위 링크

<br><br>
