### PR TITLE
feat: 추천인 코드 이벤트 참여 시 추천인에게 포인트 지급 알림 기능 추가

### DIFF
--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -306,7 +306,7 @@ public class NotificationService {
             String title = isKorean ? INVITATION_REWARD_TITLE_KR : INVITATION_REWARD_TITLE_EN;
             String body = isKorean ? INVITATION_REWARD_BODY_KR : INVITATION_REWARD_BODY_EN;
             Map<String, Object> data = Map.of(
-                    "type", "POINT_REWARD"
+                    "type", "POINT"
             );
             sendToExpo(RequestNotification.builder()
                     .to(token)

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -74,6 +74,12 @@ public class NotificationService {
     private static final String CHAT_ACCEPT_BODY_KR = "대화를 시작해보세요!";
     private static final String CHAT_ACCEPT_BODY_EN = "Start the conversation now!";
 
+    private static final String INVITATION_REWARD_TITLE_KR = "포인트가 지급되었어요!";
+    private static final String INVITATION_REWARD_TITLE_EN = "You have received points!";
+
+    private static final String INVITATION_REWARD_BODY_KR = "추천 이벤트 참여로 포인트가 적립되었어요.";
+    private static final String INVITATION_REWARD_BODY_EN = "You received points from a referral event.";
+
     @Value("${EXPO.API.URL}")
     private String expoApiUrl;
 
@@ -291,6 +297,27 @@ public class NotificationService {
 
     private String getChatAcceptBody(boolean isKorean) {
         return isKorean ? CHAT_ACCEPT_BODY_KR : CHAT_ACCEPT_BODY_EN;
+    }
+
+    public void sendInvitationRewardNotification(Student student) {
+        try {
+            String token = getTokenByUserId(student.getId());
+            boolean isKorean = student.getIsKorean();
+            String title = isKorean ? INVITATION_REWARD_TITLE_KR : INVITATION_REWARD_TITLE_EN;
+            String body = isKorean ? INVITATION_REWARD_BODY_KR : INVITATION_REWARD_BODY_EN;
+            Map<String, Object> data = Map.of(
+                    "type", "POINT_REWARD"
+            );
+            sendToExpo(RequestNotification.builder()
+                    .to(token)
+                    .title(title)
+                    .body(body)
+                    .data(data)
+                    .build()
+            );
+        } catch (NotificationException e) {
+            log.warn("추천인 포인트 지급 알림 전송 실패: {}", e.exceptionType().errorMessage());
+        }
     }
 
     private void sendToExpo(RequestNotification notification) {

--- a/src/main/java/com/team/buddyya/student/service/InvitationService.java
+++ b/src/main/java/com/team/buddyya/student/service/InvitationService.java
@@ -5,6 +5,7 @@ import com.team.buddyya.certification.domain.RegisteredPhone;
 import com.team.buddyya.certification.exception.PhoneAuthenticationException;
 import com.team.buddyya.certification.exception.PhoneAuthenticationExceptionType;
 import com.team.buddyya.certification.repository.RegisteredPhoneRepository;
+import com.team.buddyya.notification.service.NotificationService;
 import com.team.buddyya.point.domain.Point;
 import com.team.buddyya.point.domain.PointType;
 import com.team.buddyya.point.service.UpdatePointService;
@@ -33,6 +34,7 @@ public class InvitationService {
     private final UpdatePointService updatePointService;
     private final FindStudentService findStudentService;
     private final StudentRepository studentRepository;
+    private final NotificationService notificationService;
 
     public String createInvitationCode() {
         return generateUniqueCode();
@@ -52,6 +54,7 @@ public class InvitationService {
         validateNotAlreadyParticipated(requestedPhone);
         Point point = updatePointService.updatePoint(requestedStudent, PointType.INVITATION_EVENT);
         updatePointService.updatePoint(invitingStudent, PointType.INVITATION_EVENT);
+        notificationService.sendInvitationRewardNotification(invitingStudent);
         requestedPhone.markAsInvitationEventParticipated();
         return ValidateInvitationCodeResponse.from(point, PointType.INVITATION_EVENT);
     }


### PR DESCRIPTION
## 📌 관련 이슈
[추천인 코드 이벤트 참여 시 추천인에게 포인트 지급 알림 기능 추가](https://github.com/buddy-ya/be/issues/260)[#260]

<br><br>

## 🛠️ 작업 내용
- 추천인 코드 이벤트 참여 시 추천인에게 포인트 지급 알림 기능 추가

<br><br>

## 🎯 리뷰 포인트
- 알림 제목과 본문이 적절한가?
```
    private static final String INVITATION_REWARD_TITLE_KR = "포인트가 지급되었어요!";
    private static final String INVITATION_REWARD_TITLE_EN = "You have received points!";

    private static final String INVITATION_REWARD_BODY_KR = "추천 이벤트 참여로 포인트가 적립되었어요.";
    private static final String INVITATION_REWARD_BODY_EN = "You received points from a referral event.";
```

<br><br>

## 📎 커밋 범위 링크

<br><br>
