### PR TITLE
feat: 매칭 요청을 거절하거나 24시간이 지났을 경우 포인트 환급 로직 추가

### DIFF
--- a/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
@@ -83,6 +83,7 @@ public class ChatRequestService {
 
     public void deleteChatRequest(CustomUserDetails userDetails, Long chatRequestId) {
         Student sender = findStudentService.findByStudentId(userDetails.getStudentInfo().id());
+        updatePointService.updatePoint(sender, PointType.REJECTED_CHAT_REQUEST);
         chatRequestRepository.deleteById(chatRequestId);
     }
 
@@ -90,7 +91,9 @@ public class ChatRequestService {
     public void deleteExpiredChatRequests() {
         LocalDateTime expirationTime = LocalDateTime.now().minusDays(EXPIRED_CHAT_REQUEST_DAY);
         List<ChatRequest> expiredChatRequests = chatRequestRepository.findAllByCreatedDateBefore(expirationTime);
-        // TO DO: 포인트 환급 등 진행
+        expiredChatRequests.stream()
+                .map(ChatRequest::getSender)
+                .forEach(sender -> updatePointService.updatePoint(sender, PointType.REJECTED_CHAT_REQUEST));
         chatRequestRepository.deleteByCreatedDateBefore(expirationTime);
     }
 

--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -16,6 +16,7 @@ public enum PointType {
     MATCH_REQUEST("match_request", -35, PointChangeType.DEDUCT),
     CANCEL_MATCH_REQUEST("cancel_match_request", 35, PointChangeType.EARN),
     NO_POINT_CHANGE("no_point_change", 0, PointChangeType.NONE),
+    REJECTED_CHAT_REQUEST("rejected_chat_request", 15, PointChangeType.EARN),
     CHATROOM_NO_RESPONSE_REFUND("chatroom_no_response_refund", 35, PointChangeType.EARN);
 
     private final String displayName;


### PR DESCRIPTION
## 📌 관련 이슈
[매칭 요청을 거절하거나 24시간이 지났을 경우 포인트 환급](https://github.com/buddy-ya/be/issues/259)[#269]

<br><br>

## 🛠️ 작업 내용
- 매칭 요청을 거절하면 포인트 환급
- 매칭 요청을 한지 24시간이 지났을 때 상대방이 승인하지 않으면 포인트 환급

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
