### PR TITLE
feat: 매칭 요청을 거절시에 거절하는 주체가 포인트 환급받는 오류 수정

### DIFF
--- a/src/main/java/com/team/buddyya/chatting/exception/ChatExceptionType.java
+++ b/src/main/java/com/team/buddyya/chatting/exception/ChatExceptionType.java
@@ -9,7 +9,8 @@ public enum ChatExceptionType implements BaseExceptionType {
     USER_NOT_PART_OF_CHATROOM(5002, HttpStatus.FORBIDDEN, "User is not part of the chatroom."),
     SELF_CHAT_REQUEST_NOT_ALLOWED(5003, HttpStatus.BAD_REQUEST, "Cannot send a chat request to yourself."),
     CHAT_REQUEST_ALREADY_EXISTS(5004, HttpStatus.BAD_REQUEST, "Chat request already sent."),
-    CHATROOM_ALREADY_EXISTS(5005, HttpStatus.BAD_REQUEST, "Chatroom already exists.");
+    CHATROOM_ALREADY_EXISTS(5005, HttpStatus.BAD_REQUEST, "Chatroom already exists."),
+    CHAT_REQUEST_NOT_FOUND(5006, HttpStatus.BAD_REQUEST, "ChatRequest not found.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
@@ -17,6 +17,7 @@ import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import com.team.buddyya.point.service.PointService;
 import lombok.RequiredArgsConstructor;
@@ -82,8 +83,9 @@ public class ChatRequestService {
     }
 
     public void deleteChatRequest(CustomUserDetails userDetails, Long chatRequestId) {
-        Student sender = findStudentService.findByStudentId(userDetails.getStudentInfo().id());
-        updatePointService.updatePoint(sender, PointType.REJECTED_CHAT_REQUEST);
+        ChatRequest chatRequest = chatRequestRepository.findById(chatRequestId)
+                .orElseThrow(()-> new ChatException(ChatExceptionType.CHAT_REQUEST_NOT_FOUND));
+        updatePointService.updatePoint(chatRequest.getSender(), PointType.REJECTED_CHAT_REQUEST);
         chatRequestRepository.deleteById(chatRequestId);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
[매칭 요청을 거절시에 거절하는 주체가 포인트 환급받는 오류 수정](https://github.com/buddy-ya/be/issues/271)[#271]

<br><br>

## 🛠️ 작업 내용
- 매칭 요절 거절 시 유저 아이디로 유저를 조회하는 것이 아닌 `chatRequestId`로 `chatRequest`를 조회해야 합니다.
`chatRequest`조회 후 해당 `chatRequest`의 sender의 `Point`를 환급 해주는 것으로 수정하였습니다. 

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
