### PR TITLE
refactor: 문자 인증 코드 전송은 영문으로 수정

### DIFF
--- a/src/main/java/com/team/buddyya/certification/service/MessageSendService.java
+++ b/src/main/java/com/team/buddyya/certification/service/MessageSendService.java
@@ -25,7 +25,7 @@ import java.util.Random;
 public class MessageSendService {
 
     private static final String SOLAPI_API_URL = "https://api.solapi.com";
-    private static final String MESSAGE_TEXT_FORMAT = "[버디야] 본인 확인 인증번호[%s]를 화면에 입력해주세요";
+    private static final String MESSAGE_TEXT_FORMAT = "[Buddyya] Enter the code [%s] on the screen to confirm it's you!";
     private static final String MESSAGE_SEND_SUCCESS_STATUS_CODE = "2000";
     private static final int AUTH_CODE_MAX_RANGE = 1_000_000;
 


### PR DESCRIPTION
## 📌 관련 이슈
[문자 인증 코드 전송은 영문으로 수정](https://github.com/buddy-ya/be/issues/274)[#274]

<br><br>

## 🛠️ 작업 내용
- 문자 인증 코드 전송은 영문으로 수정

<br><br>

## 🎯 리뷰 포인트
- 영문 문자 메시지가 자연스러운가요?
`private static final String MESSAGE_TEXT_FORMAT = "[Buddyya] Enter the code [%s] on the screen to confirm it's you!";`


<br><br>

## 📎 커밋 범위 링크

<br><br>
