### PR TITLE
대댓글 알림 오류 수정 및 응답 없음 포인트 환급 알림 추가

### DIFF
--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -57,14 +57,12 @@ public class AdminService {
     private final FindStudentService findStudentService;
     private final S3UploadService s3UploadService;
     private final NotificationService notificationService;
-    private final FindPointService findPointService;
     private final UpdatePointService updatePointService;
     private final StudentIdCardRepository studentIdCardRepository;
     private final ReportRepository reportRepository;
     private final ReportImageRepository reportImageRepository;
     private final ChatroomRepository chatroomRepository;
     private final ChatRepository chatRepository;
-    private final PointStatusRepository pointStatusRepository;
 
     @Transactional(readOnly = true)
     public List<StudentIdCardResponse> getStudentIdCards() {
@@ -146,6 +144,7 @@ public class AdminService {
         if (chatroom.getType().equals(ChatroomType.MATCHING)) {
             Student reportUser = findStudentService.findByStudentId(reportUserId);
             updatePointService.updatePoint(reportUser, PointType.CHATROOM_NO_RESPONSE_REFUND);
+            notificationService.sendRefundNotification(reportUser);
         }
     }
 }

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -71,11 +71,12 @@ public class CommentService {
         Comment parent = null;
         if (request.parentId() != null) {
             parent = findCommentByCommentId(request.parentId());
-            boolean isParent = parent.isParent(studentInfo.id());
             if (parent.getParent() != null) {
                 throw new FeedException(FeedExceptionType.COMMENT_DEPTH_LIMIT);
             }
-            if(!isFeedOwner && !isParent) {
+            boolean isWriterParent = parent.isParent(studentInfo.id());
+            boolean isParentFeedOwner = parent.isParent(feed.getStudent().getId());
+            if(!isFeedOwner && !isWriterParent && !isParentFeedOwner) {
                 notificationService.sendCommentReplyNotification(feed, parent, request.content());
             }
         }

--- a/src/main/java/com/team/buddyya/feed/service/CommentService.java
+++ b/src/main/java/com/team/buddyya/feed/service/CommentService.java
@@ -67,18 +67,13 @@ public class CommentService {
     public void createComment(StudentInfo studentInfo, Long feedId, CommentCreateRequest request) {
         Student student = findStudentService.findByStudentId(studentInfo.id());
         Feed feed = findFeedByFeedId(feedId);
-        boolean isFeedOwner = feed.isFeedOwner(studentInfo.id());
         Comment parent = null;
         if (request.parentId() != null) {
             parent = findCommentByCommentId(request.parentId());
             if (parent.getParent() != null) {
                 throw new FeedException(FeedExceptionType.COMMENT_DEPTH_LIMIT);
             }
-            boolean isWriterParent = parent.isParent(studentInfo.id());
-            boolean isParentFeedOwner = parent.isParent(feed.getStudent().getId());
-            if(!isFeedOwner && !isWriterParent && !isParentFeedOwner) {
-                notificationService.sendCommentReplyNotification(feed, parent, request.content());
-            }
+            notificationService.sendCommentReplyNotification(studentInfo.id(), feed, parent, request.content());
         }
         Comment comment = Comment.builder()
                 .student(student)
@@ -87,9 +82,7 @@ public class CommentService {
                 .parent(parent)
                 .build();
         commentRepository.save(comment);
-        if(!isFeedOwner) {
-            notificationService.sendCommentNotification(feed, request.content());
-        }
+        notificationService.sendCommentNotification(studentInfo.id(), feed, request.content());
     }
 
     public void updateComment(StudentInfo studentInfo, Long feedId, Long commentId,

--- a/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
+++ b/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
@@ -215,7 +215,6 @@ public class BasicMatchService implements MatchService {
         notificationService.sendMatchSuccessNotification(matchedStudent, chatroom.getId());
         MatchingProfile matchingProfile = matchingProfileRepository.findByStudent(matchedStudent)
                 .orElseThrow(() -> new MatchException(MatchExceptionType.MATCH_PROFILE_NOT_FOUND));
-        log.info("🤝 Successfully matched: [{}] ↔ [{}]", student.getId(), matchedStudent.getId());
         return MatchResponse.from(chatroom, matchedStudent, newMatchRequest, point, false, matchingProfile);
     }
 

--- a/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
+++ b/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
@@ -215,7 +215,7 @@ public class BasicMatchService implements MatchService {
         notificationService.sendMatchSuccessNotification(matchedStudent, chatroom.getId());
         MatchingProfile matchingProfile = matchingProfileRepository.findByStudent(matchedStudent)
                 .orElseThrow(() -> new MatchException(MatchExceptionType.MATCH_PROFILE_NOT_FOUND));
-        log.info("🤝 Successfully matched: [{}] ↔ [{}]", student.getName(), matchedStudent.getName());
+        log.info("🤝 Successfully matched: [{}] ↔ [{}]", student.getId(), matchedStudent.getId());
         return MatchResponse.from(chatroom, matchedStudent, newMatchRequest, point, false, matchingProfile);
     }
 

--- a/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
+++ b/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
@@ -28,6 +28,7 @@ import com.team.buddyya.student.repository.BlockRepository;
 import com.team.buddyya.student.repository.MatchingProfileRepository;
 import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +42,7 @@ import static com.team.buddyya.chatting.domain.ChatroomType.MATCHING;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class BasicMatchService implements MatchService {
 
     private final MatchRequestRepository matchRequestRepository;
@@ -213,6 +215,7 @@ public class BasicMatchService implements MatchService {
         notificationService.sendMatchSuccessNotification(matchedStudent, chatroom.getId());
         MatchingProfile matchingProfile = matchingProfileRepository.findByStudent(matchedStudent)
                 .orElseThrow(() -> new MatchException(MatchExceptionType.MATCH_PROFILE_NOT_FOUND));
+        log.info("🤝 Successfully matched: [{}] ↔ [{}]", student.getName(), matchedStudent.getName());
         return MatchResponse.from(chatroom, matchedStudent, newMatchRequest, point, false, matchingProfile);
     }
 

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -140,24 +140,29 @@ public class NotificationService {
         return isKorean ? MATCH_SUCCESS_BODY_KR: MATCH_SUCCESS_BODY_EN;
     }
 
-    public void sendCommentReplyNotification(Feed feed, Comment parent, String commentContent){
-        try{
-            Student recipient = parent.getStudent();
-            String token = getTokenByUserId(recipient.getId());
-            Map<String, Object> data = Map.of(
-                    "feedId", feed.getId(),
-                    "type", "FEED"
-            );
-            boolean isKorean = recipient.getIsKorean();
-            String title = getCommentReplyNotificationTitle(isKorean);
-            sendToExpo(RequestNotification.builder()
-                    .to(token)
-                    .title(title)
-                    .body(commentContent)
-                    .data(data).build()
-            );
-        } catch (NotificationException e) {
-            log.warn("피드 대댓글 알림 전송 실패: {}", e.exceptionType().errorMessage());
+    public void sendCommentReplyNotification(Long writerId, Feed feed, Comment parent, String commentContent){
+        boolean isFeedOwner = feed.isFeedOwner(writerId);
+        boolean isWriterParent = parent.isParent(writerId);
+        boolean isParentFeedOwner = parent.isParent(feed.getStudent().getId());
+        if(!isFeedOwner && !isWriterParent && !isParentFeedOwner) {
+            try {
+                Student recipient = parent.getStudent();
+                String token = getTokenByUserId(recipient.getId());
+                Map<String, Object> data = Map.of(
+                        "feedId", feed.getId(),
+                        "type", "FEED"
+                );
+                boolean isKorean = recipient.getIsKorean();
+                String title = getCommentReplyNotificationTitle(isKorean);
+                sendToExpo(RequestNotification.builder()
+                        .to(token)
+                        .title(title)
+                        .body(commentContent)
+                        .data(data).build()
+                );
+            } catch (NotificationException e) {
+                log.warn("피드 대댓글 알림 전송 실패: {}", e.exceptionType().errorMessage());
+            }
         }
     }
 
@@ -165,24 +170,27 @@ public class NotificationService {
         return isKorean ? FEED_REPLY_TITLE_KR: FEED_REPLY_TITLE_EN;
     }
 
-    public void sendCommentNotification(Feed feed, String commentContent) {
-        try {
-            Student recipient = feed.getStudent();
-            String token = getTokenByUserId(recipient.getId());
-            Map<String, Object> data = Map.of(
-                    "feedId", feed.getId(),
-                    "type", "FEED"
-            );
-            boolean isKorean = recipient.getIsKorean();
-            String title = getCommentNotificationTitle(isKorean);
-            sendToExpo(RequestNotification.builder()
-                    .to(token)
-                    .title(title)
-                    .body(commentContent)
-                    .data(data).build()
-            );
-        } catch (NotificationException e) {
-            log.warn("피드 알림 전송 실패: {}", e.exceptionType().errorMessage());
+    public void sendCommentNotification(Long writerId, Feed feed, String commentContent) {
+        boolean isFeedOwner = feed.isFeedOwner(writerId);
+        if(!isFeedOwner) {
+            try {
+                Student recipient = feed.getStudent();
+                String token = getTokenByUserId(recipient.getId());
+                Map<String, Object> data = Map.of(
+                        "feedId", feed.getId(),
+                        "type", "FEED"
+                );
+                boolean isKorean = recipient.getIsKorean();
+                String title = getCommentNotificationTitle(isKorean);
+                sendToExpo(RequestNotification.builder()
+                        .to(token)
+                        .title(title)
+                        .body(commentContent)
+                        .data(data).build()
+                );
+            } catch (NotificationException e) {
+                log.warn("피드 알림 전송 실패: {}", e.exceptionType().errorMessage());
+            }
         }
     }
 

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -80,6 +80,12 @@ public class NotificationService {
     private static final String INVITATION_REWARD_BODY_KR = "추천 이벤트 참여로 포인트가 적립되었어요.";
     private static final String INVITATION_REWARD_BODY_EN = "You received points from a referral event.";
 
+    private static final String REFUND_POINTS_TITLE_KR = "포인트가 환급되었어요!";
+    private static final String REFUND_POINTS_TITLE_EN = "Your points have been refunded!";
+
+    private static final String REFUND_POINTS_BODY_KR = "채팅 상대방의 미응답을 확인하여 포인트를 환급해드렸어요.";
+    private static final String REFUND_POINTS_BODY_EN = "We confirmed no response from your chat partner and refunded your points.";
+
     @Value("${EXPO.API.URL}")
     private String expoApiUrl;
 
@@ -317,6 +323,27 @@ public class NotificationService {
             );
         } catch (NotificationException e) {
             log.warn("추천인 포인트 지급 알림 전송 실패: {}", e.exceptionType().errorMessage());
+        }
+    }
+
+    public void sendRefundNotification(Student student) {
+        try {
+            String token = getTokenByUserId(student.getId());
+            boolean isKorean = student.getIsKorean();
+            String title = isKorean ? REFUND_POINTS_TITLE_KR : REFUND_POINTS_TITLE_EN;
+            String body = isKorean ? REFUND_POINTS_BODY_KR : REFUND_POINTS_BODY_EN;
+            Map<String, Object> data = Map.of(
+                    "type", "POINT"
+            );
+            sendToExpo(RequestNotification.builder()
+                    .to(token)
+                    .title(title)
+                    .body(body)
+                    .data(data)
+                    .build()
+            );
+        } catch (NotificationException e) {
+            log.warn("무응답 포인트 환급 알림 전송 실패: {}", e.exceptionType().errorMessage());
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
[대댓글 알림 오류 수정 및 응답 없음 포인트 환급 알림 추가](https://github.com/buddy-ya/be/issues/283)[#283]

<br><br>

## 🛠️ 작업 내용
- 대댓글 알림 오류 수정
`대댓글 작성 시`
1. 댓글 작성자가 `피드의 주인`이면 알림 전송 가면 안됨
-> 피드의 주인 스스로에게 대댓글 알림 가는 것을 방지
2. 댓글 작성자가 `댓글의 주인`이면 알림 전송 가면 안됨
-> 댓글의 주인 스스로에게 대댓글 알림 가는 것을 방지
3. **`댓글의 주인`이 `피드의 주인`이면 알림 전송 가면 안됨 ( 처리 안되어었던 로직 )**
-> 피드의 주인에게 `일반 댓글 알림` + `대댓글 알림` 한번에 두개의 알림이 가는 것을 방지

- 응답 없음 포인트 환급 알림 추가

- 매칭 성공 시 로그 추가

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
