### PR TITLE
feat: 중국어를 사용할 수 있는 유저는 중국어 사용 유저와 우선적으로 매칭

### DIFF
--- a/src/main/java/com/team/buddyya/match/domain/MatchRequest.java
+++ b/src/main/java/com/team/buddyya/match/domain/MatchRequest.java
@@ -44,11 +44,11 @@ public class MatchRequest extends BaseTime {
     @Column(name = "match_request_status", nullable = false)
     private MatchRequestStatus matchRequestStatus;
 
-    @Column(name = "korean", nullable = false)
-    private Boolean isKorean;
+    @Column(name = "chinese_available", nullable = false)
+    private Boolean isChineseAvailable;
 
     @Builder
-    public MatchRequest(Student student, Long chatroomId, Long universityId, NationalityType nationalityType, UniversityType universityType, GenderType genderType, MatchRequestStatus matchRequestStatus, Boolean isKorean) {
+    public MatchRequest(Student student, Long chatroomId, Long universityId, NationalityType nationalityType, UniversityType universityType, GenderType genderType, MatchRequestStatus matchRequestStatus, Boolean isChineseAvailable) {
         this.student = student;
         this.chatroomId = chatroomId;
         this.nationalityType = nationalityType;
@@ -56,7 +56,7 @@ public class MatchRequest extends BaseTime {
         this.universityType = universityType;
         this.genderType = genderType;
         this.matchRequestStatus = matchRequestStatus;
-        this.isKorean = isKorean;
+        this.isChineseAvailable = isChineseAvailable;
     }
 
     public void updateMatchRequestStatusSuccess() {

--- a/src/main/java/com/team/buddyya/match/repository/MatchRequestRepository.java
+++ b/src/main/java/com/team/buddyya/match/repository/MatchRequestRepository.java
@@ -13,6 +13,13 @@ import java.util.Optional;
 public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
 
     @Query("""
+    SELECT m FROM MatchRequest m
+    WHERE m.matchRequestStatus = 'MATCH_PENDING'
+    ORDER BY m.isChineseAvailable DESC, m.createdDate ASC
+    """)
+    List<MatchRequest> findAllPendingMatchesPrioritizeChinese();
+
+    @Query("""
         SELECT m FROM MatchRequest m 
         WHERE m.matchRequestStatus = 'MATCH_PENDING'
         ORDER BY m.createdDate ASC

--- a/src/main/java/com/team/buddyya/student/repository/StudentLanguageRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/StudentLanguageRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface StudentLanguageRepository extends JpaRepository<StudentLanguage, Long> {
 
     void deleteByStudent(Student student);
+
+    boolean existsByStudentAndLanguage_Id(Student student, Long languageId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
[중국어를 사용할 수 있는 유저는 중국어 사용 유저와 우선적으로 매칭](https://github.com/buddy-ya/be/issues/288)[#288]

<br><br>

## 🛠️ 작업 내용
- 매칭 요청 시 만약 요청자가 중국어를 할 수 있는 경우 대기 큐에 중국어를 사용할 수 있는 유저를 우선적으로
매칭 해주는 로직 추가

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
