### PR TITLE
fix: 댓글 작성자가 피드의 주인이라도 알림을 보내도록 변경

### DIFF
--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -141,10 +141,9 @@ public class NotificationService {
     }
 
     public void sendCommentReplyNotification(Long writerId, Feed feed, Comment parent, String commentContent){
-        boolean isFeedOwner = feed.isFeedOwner(writerId);
         boolean isWriterParent = parent.isParent(writerId);
         boolean isParentFeedOwner = parent.isParent(feed.getStudent().getId());
-        if(!isFeedOwner && !isWriterParent && !isParentFeedOwner) {
+        if(!isWriterParent && !isParentFeedOwner) {
             try {
                 Student recipient = parent.getStudent();
                 String token = getTokenByUserId(recipient.getId());


### PR DESCRIPTION
## 📌 관련 이슈
[피드 주인이 대댓글 달시 대댓글 주인에게 알림이 가지 않는 오류 수정](https://github.com/buddy-ya/be/issues/294)[#294]

<br><br>

## 🛠️ 작업 내용

현재 대댓글 작성 시 아래 세 경우 대댓글 알림을 보내지 않습니다. 

1. 댓글 작성자가 피드의 주인이면 알림 전송 가면 안됨
-> 피드의 주인 스스로에게 대댓글 알림 가는 것을 방지
2. 댓글 작성자가 댓글의 주인이면 알림 전송 가면 안됨
-> 댓글의 주인 스스로에게 대댓글 알림 가는 것을 방지
3. 댓글의 주인이 피드의 주인이면 알림 전송 가면 안됨
-> 피드의 주인에게 일반 댓글 알림 + 대댓글 알림 한번에 두개의 알림이 가는 것을 방지

하지만 1번에서 댓글 작성자가 단순히 피드의 주인이라고 대댓글 알림을 보내면 안됩니다.
중복으로 알림이 가는것은 3번째에서 검사하기 때문에 첫번째 예외를 제거해야 합니다.

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
