### PR TITLE
fix: 관리자 학생증 반려 시 재조회되지 않도록 수정

### DIFF
--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -19,8 +19,6 @@ import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.notification.service.NotificationService;
 import com.team.buddyya.point.domain.PointType;
-import com.team.buddyya.point.repository.PointStatusRepository;
-import com.team.buddyya.point.service.FindPointService;
 import com.team.buddyya.point.service.UpdatePointService;
 import com.team.buddyya.report.domain.Report;
 import com.team.buddyya.report.domain.ReportImage;
@@ -66,7 +64,8 @@ public class AdminService {
 
     @Transactional(readOnly = true)
     public List<StudentIdCardResponse> getStudentIdCards() {
-        return studentIdCardRepository.findAllByOrderByCreatedDateAsc().stream()
+        return studentIdCardRepository.findUploadStudentIdCards()
+                .stream()
                 .map(StudentIdCardResponse::from)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/team/buddyya/certification/repository/StudentIdCardRepository.java
+++ b/src/main/java/com/team/buddyya/certification/repository/StudentIdCardRepository.java
@@ -3,6 +3,7 @@ package com.team.buddyya.certification.repository;
 import com.team.buddyya.certification.domain.StudentIdCard;
 import com.team.buddyya.student.domain.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +18,7 @@ public interface StudentIdCardRepository extends JpaRepository<StudentIdCard, Lo
     void deleteByStudent(Student student);
 
     Optional<StudentIdCard> findByStudent_Id(Long studentId);
+
+    @Query("SELECT s FROM StudentIdCard s WHERE s.rejectionReason IS NULL ORDER BY s.createdDate ASC")
+    List<StudentIdCard> findUploadStudentIdCards();
 }


### PR DESCRIPTION
## 📌 관련 이슈
[관리자가 반려한 학생증 재조회 되지 않게 수정 [#300]](https://github.com/buddy-ya/be/issues/300)
<br><br>

## 🛠️ 작업 내용
- 관리자가 반려한 학생증 재조회 되지 않게 수정
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
