### PR TITLE
feat: 출석 이벤트 포인트 지급 기능 구현

### DIFF
--- a/src/main/java/com/team/buddyya/certification/domain/RegisteredPhone.java
+++ b/src/main/java/com/team/buddyya/certification/domain/RegisteredPhone.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.*;
 
@@ -34,6 +36,9 @@ public class RegisteredPhone extends CreatedTime {
     @Column(name = "has_withdrawn", nullable = false)
     private Boolean hasWithdrawn;
 
+    @Column(name = "last_attendance_date")
+    private LocalDate lastAttendanceDate;
+
     @Builder
     public RegisteredPhone(String phoneNumber, String authenticationCode, String invitationCode) {
         this.phoneNumber = phoneNumber;
@@ -41,6 +46,7 @@ public class RegisteredPhone extends CreatedTime {
         this.invitationCode = invitationCode;
         this.invitationEventParticipated = false;
         this.hasWithdrawn = false;
+        lastAttendanceDate = null;
     }
 
     public void updateAuthenticationCode(String authenticationCode) {
@@ -51,5 +57,14 @@ public class RegisteredPhone extends CreatedTime {
 
     public void updateHasWithDrawn(boolean hasWithdrawn) {
         this.hasWithdrawn = hasWithdrawn;
+    }
+
+    public boolean isTodayAlreadyChecked() {
+        LocalDate today = LocalDate.now();
+        return lastAttendanceDate != null && lastAttendanceDate.isEqual(today);
+    }
+
+    public void updateLastAttendanceDateToToday() {
+        this.lastAttendanceDate = LocalDate.now();
     }
 }

--- a/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
+++ b/src/main/java/com/team/buddyya/certification/service/PhoneAuthenticationService.java
@@ -79,7 +79,12 @@ public class PhoneAuthenticationService {
                     phone.updateAuthenticationCode(generatedCode);
                     return phone;
                 })
-                .orElse(new RegisteredPhone(phoneNumber, generatedCode, invitationService.createInvitationCode()));
+                .orElse(RegisteredPhone.builder()
+                        .phoneNumber(phoneNumber)
+                        .authenticationCode(generatedCode)
+                        .invitationCode(invitationService.createInvitationCode())
+                        .build()
+                );
     }
 
     public TestAccountResponse isTestAccount(String phoneNumber) {

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -86,6 +86,12 @@ public class NotificationService {
     private static final String REFUND_POINTS_BODY_KR = "채팅 상대방의 미응답을 확인하여 포인트를 환급해드렸어요.";
     private static final String REFUND_POINTS_BODY_EN = "We confirmed no response from your chat partner and refunded your points.";
 
+    private static final String ATTENDANCE_REWARD_TITLE_KR = "출석 완료!";
+    private static final String ATTENDANCE_REWARD_TITLE_EN = "Checked In!";
+
+    private static final String ATTENDANCE_REWARD_BODY_KR = "매일 출석하면 포인트가 쌓여요. 오늘도 +10포인트 적립!";
+    private static final String ATTENDANCE_REWARD_BODY_EN = "You’ve earned 10 points for checking in today. Come back daily for more!";
+
     @Value("${EXPO.API.URL}")
     private String expoApiUrl;
 
@@ -367,6 +373,29 @@ public class NotificationService {
             );
         } catch (NotificationException e) {
             log.warn("무응답 포인트 환급 알림 전송 실패: {}", e.exceptionType().errorMessage());
+        }
+    }
+
+    public void sendDailyAttendanceNotification(Student student) {
+        try {
+            String token = getTokenByUserId(student.getId());
+            boolean isKorean = student.getIsKorean();
+            String title = isKorean ? ATTENDANCE_REWARD_TITLE_KR : ATTENDANCE_REWARD_TITLE_EN;
+            String body = isKorean ? ATTENDANCE_REWARD_BODY_KR : ATTENDANCE_REWARD_BODY_EN;
+            Map<String, Object> data = Map.of(
+                    "type", "POINT"
+            );
+            sendToExpo(RequestNotification.builder()
+                    .to(token)
+                    .title(title)
+                    .body(body)
+                    .priority("high")
+                    .channelId("default")
+                    .data(data)
+                    .build()
+            );
+        } catch (NotificationException e) {
+            log.warn("출석 이벤트 알림 전송 실패: {}", e.exceptionType().errorMessage());
         }
     }
 

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -89,7 +89,7 @@ public class NotificationService {
     private static final String ATTENDANCE_REWARD_TITLE_KR = "출석 완료!";
     private static final String ATTENDANCE_REWARD_TITLE_EN = "Checked In!";
 
-    private static final String ATTENDANCE_REWARD_BODY_KR = "매일 출석하면 포인트가 쌓여요. 오늘도 +10포인트 적립!";
+    private static final String ATTENDANCE_REWARD_BODY_KR = "매일 출석하면 포인트가 쌓여요. 오늘도 +15포인트 적립!";
     private static final String ATTENDANCE_REWARD_BODY_EN = "You’ve earned 10 points for checking in today. Come back daily for more!";
 
     @Value("${EXPO.API.URL}")

--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -11,13 +11,14 @@ public enum PointType {
 
     SIGNUP("signup", 100, PointChangeType.EARN),
     UNIVERSITY_AUTH("university_auth", 1, PointChangeType.EARN),
-    INVITATION_EVENT("invitation_event", 50, PointChangeType.EARN),
+    INVITATION_EVENT("invitation_event", 100, PointChangeType.EARN),
     CHAT_REQUEST("chat_request", -15, PointChangeType.DEDUCT),
     MATCH_REQUEST("match_request", -35, PointChangeType.DEDUCT),
     CANCEL_MATCH_REQUEST("cancel_match_request", 35, PointChangeType.EARN),
     NO_POINT_CHANGE("no_point_change", 0, PointChangeType.NONE),
     REJECTED_CHAT_REQUEST("rejected_chat_request", 15, PointChangeType.EARN),
-    CHATROOM_NO_RESPONSE_REFUND("chatroom_no_response_refund", 35, PointChangeType.EARN);
+    CHATROOM_NO_RESPONSE_REFUND("chatroom_no_response_refund", 35, PointChangeType.EARN),
+    EVENT_REWARD("event_reward", 15, PointChangeType.EARN);
 
     private final String displayName;
     private final int pointChange;

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -12,10 +12,13 @@ import com.team.buddyya.chatting.domain.ChatroomStudent;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.match.repository.MatchRequestRepository;
 import com.team.buddyya.notification.repository.ExpoTokenRepository;
+import com.team.buddyya.notification.service.NotificationService;
 import com.team.buddyya.point.domain.Point;
+import com.team.buddyya.point.domain.PointType;
 import com.team.buddyya.point.repository.PointRepository;
 import com.team.buddyya.point.repository.PointStatusRepository;
 import com.team.buddyya.point.service.FindPointService;
+import com.team.buddyya.point.service.UpdatePointService;
 import com.team.buddyya.student.domain.*;
 import com.team.buddyya.student.dto.request.MyPageUpdateRequest;
 import com.team.buddyya.student.dto.request.OnBoardingRequest;
@@ -32,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.team.buddyya.common.domain.S3DirectoryName.PROFILE_IMAGE;
@@ -60,6 +64,8 @@ public class StudentService {
     private final PointStatusRepository pointStatusRepository;
     private final MatchRequestRepository matchRequestRepository;
     private final MatchingProfileRepository matchingProfileRepository;
+    private final UpdatePointService updatePointService;
+    private final NotificationService notificationService;
 
     private static final String BLOCK_SUCCESS_MESSAGE = "차단이 성공적으로 완료되었습니다.";
 
@@ -153,6 +159,7 @@ public class StudentService {
         if (!studentInfo.id().equals(userId)) {
             return UserResponse.fromOtherUserInfo(student, matchingProfile);
         }
+        checkAttendanceAndReward(student);
         Point point = findPointService.findByStudent(student);
         boolean isStudentIdCardRequested = studentIdCardRepository.findByStudent(student)
                 .isPresent();
@@ -235,5 +242,15 @@ public class StudentService {
     private MatchingProfile getMatchingProfile(Student student) {
         return matchingProfileRepository.findByStudent(student)
                 .orElseThrow(() -> new StudentException(StudentExceptionType.MATCHING_PROFILE_NOT_FOUND));
+    }
+
+    public void checkAttendanceAndReward(Student student) {
+        RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
+                .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));
+        if (!registeredPhone.isTodayAlreadyChecked()) {
+            updatePointService.updatePoint(student, PointType.EVENT_REWARD);
+            registeredPhone.updateLastAttendanceDateToToday();
+            notificationService.sendDailyAttendanceNotification(student);
+        }
     }
 }

--- a/src/main/resources/db/migration/V22__Add_last_attendance_date_registred_phone_info.sql
+++ b/src/main/resources/db/migration/V22__Add_last_attendance_date_registred_phone_info.sql
@@ -1,0 +1,2 @@
+ALTER TABLE registered_phone_number
+    ADD last_attendance_date date NULL;


### PR DESCRIPTION
## 📌 관련 이슈
[출석 이벤트 포인트 지급 기능](https://github.com/buddy-ya/be/issues/303)[#303]

<br><br>

## 🛠️ 작업 내용
- 유저가 하루에 한번 앱에 접속하면 15포인트를 지급한다.
- 유저가 하루에 마지막으로 접속한 날짜를 기록하는 컬럼 추가 (`lastAttendanceDate`)
- 출석 이벤트 포인트 지급 기능 구현

`접속시 동작 흐름`
1. 사용자가 앱 접속하여 나의 정보 조회(getUserInfo 호출)
2. `RegisteredPhone`에서 해당 유저의 `lastAttendanceDate` 조회
3. 오늘 날짜와 비교:
   - 같으면: 아무 일도 하지 않음 (이미 출석 완료)
   - 다르면 or 방금 회원가입하여서 null값일 때:
     1. lastAttendanceDate = 오늘 날짜로 업데이트
     2. 포인트 지급
     3. 알림 메시지 전송

- 친구 초대 이벤트 추가 포인트 `+50` -> `+100`으로 증가

<br><br>

## 🎯 리뷰 포인트
- 코드 컨벤션에 어긋난 부분은 없나요?
- 알림 내용은 적당한 가요?
```
    private static final String ATTENDANCE_REWARD_TITLE_KR = "출석 완료!";
    private static final String ATTENDANCE_REWARD_TITLE_EN = "Checked In!";

    private static final String ATTENDANCE_REWARD_BODY_KR = "매일 출석하면 포인트가 쌓여요. 오늘도 +15포인트 적립!";
    private static final String ATTENDANCE_REWARD_BODY_EN = "You’ve earned 10 points for checking in today. Come back daily for more!";

```
- 이벤트 관련 컬럼은 `RegisteredPhone`에 종속적이게 설계하도록 얘기가 되었어서, `lastAttendanceDate` 또한 해당 엔티티에 작성하였습니다. 

<br><br>

## 📎 커밋 범위 링크

<br><br>
