### PR TITLE
Refactor: 채팅 요청 생성 로직 변경 및 피드 생성시 프로필 공개 여부 포함 

### DIFF
--- a/src/main/java/com/team/buddyya/chatting/controller/ChatRequestController.java
+++ b/src/main/java/com/team/buddyya/chatting/controller/ChatRequestController.java
@@ -1,21 +1,24 @@
 package com.team.buddyya.chatting.controller;
 
+import static com.team.buddyya.chatting.domain.ChatroomType.CHAT_REQUEST;
+
 import com.team.buddyya.auth.domain.CustomUserDetails;
 import com.team.buddyya.chatting.dto.request.CreateChatroomRequest;
-import com.team.buddyya.chatting.dto.response.ChatRequestInfoResponse;
 import com.team.buddyya.chatting.dto.response.ChatRequestResponse;
-import com.team.buddyya.chatting.dto.response.CreateChatRequestResponse;
 import com.team.buddyya.chatting.dto.response.CreateChatroomResponse;
 import com.team.buddyya.chatting.service.ChatRequestService;
 import com.team.buddyya.chatting.service.ChatService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-
-import static com.team.buddyya.chatting.domain.ChatroomType.CHAT_REQUEST;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/chat-requests")
@@ -25,12 +28,12 @@ public class ChatRequestController {
     private final ChatRequestService chatRequestService;
     private final ChatService chatService;
 
-    @GetMapping("/{receiverId}")
-    public ResponseEntity<ChatRequestInfoResponse> getChatRequestInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long receiverId) {
-        return ResponseEntity.ok(chatRequestService.getChatRequestInfo(userDetails, receiverId));
-    }
+//    @GetMapping("/{receiverId}")
+//    public ResponseEntity<ChatRequestInfoResponse> getChatRequestInfo(
+//            @AuthenticationPrincipal CustomUserDetails userDetails,
+//            @PathVariable Long receiverId) {
+//        return ResponseEntity.ok(chatRequestService.getChatRequestInfo(userDetails, receiverId));
+//    }
 
     @GetMapping
     public ResponseEntity<List<ChatRequestResponse>> getChatRequests(
@@ -48,7 +51,8 @@ public class ChatRequestController {
     @PostMapping
     public ResponseEntity<CreateChatroomResponse> createOrGetChatRoom(@RequestBody CreateChatroomRequest request,
                                                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
-        CreateChatroomResponse response = chatService.createOrGetChatRoom(request, userDetails.getStudentInfo(), CHAT_REQUEST);
+        CreateChatroomResponse response = chatService.createOrGetChatRoom(request, userDetails.getStudentInfo(),
+                CHAT_REQUEST);
         chatRequestService.deleteChatRequest(request.chatRequestId());
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/team/buddyya/chatting/exception/ChatExceptionType.java
+++ b/src/main/java/com/team/buddyya/chatting/exception/ChatExceptionType.java
@@ -10,7 +10,8 @@ public enum ChatExceptionType implements BaseExceptionType {
     SELF_CHAT_REQUEST_NOT_ALLOWED(5003, HttpStatus.BAD_REQUEST, "Cannot send a chat request to yourself."),
     CHAT_REQUEST_ALREADY_EXISTS(5004, HttpStatus.BAD_REQUEST, "Chat request already sent."),
     CHATROOM_ALREADY_EXISTS(5005, HttpStatus.BAD_REQUEST, "Chatroom already exists."),
-    CHAT_REQUEST_NOT_FOUND(5006, HttpStatus.BAD_REQUEST, "ChatRequest not found.");
+    CHAT_REQUEST_NOT_FOUND(5006, HttpStatus.BAD_REQUEST, "ChatRequest not found."),
+    CHAT_REQUEST_BLOCKED(5007, HttpStatus.BAD_REQUEST, "ChatRequest blocked.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/chatting/repository/ChatroomRepository.java
+++ b/src/main/java/com/team/buddyya/chatting/repository/ChatroomRepository.java
@@ -1,11 +1,10 @@
 package com.team.buddyya.chatting.repository;
 
 import com.team.buddyya.chatting.domain.Chatroom;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
@@ -13,6 +12,16 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
             "JOIN c.chatroomStudents s1 ON s1.student.id = :userId " +
             "JOIN c.chatroomStudents s2 ON s2.student.id = :buddyId")
     Optional<Chatroom> findByUserAndBuddy(@Param("userId") Long userId, @Param("buddyId") Long buddyId);
+
+    @Query("SELECT c FROM Chatroom c " +
+            "JOIN c.chatroomStudents cs " +
+            "WHERE cs.student.id IN (:senderId, :receiverId) " +
+            "  AND cs.isExited = false " +
+            "GROUP BY c.id " +
+            "HAVING COUNT(cs) = 2 " +
+            "ORDER BY c.lastMessageTime DESC")
+    Optional<Chatroom> findLatestActiveChatroomByUserPair(@Param("senderId") Long senderId,
+                                                          @Param("receiverId") Long receiverId);
 
     Optional<Chatroom> findById(Long chatroomId);
 }

--- a/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
@@ -2,7 +2,6 @@ package com.team.buddyya.chatting.service;
 
 import com.team.buddyya.auth.domain.CustomUserDetails;
 import com.team.buddyya.chatting.domain.ChatRequest;
-import com.team.buddyya.chatting.dto.response.ChatRequestInfoResponse;
 import com.team.buddyya.chatting.dto.response.ChatRequestResponse;
 import com.team.buddyya.chatting.exception.ChatException;
 import com.team.buddyya.chatting.exception.ChatExceptionType;
@@ -10,14 +9,14 @@ import com.team.buddyya.chatting.repository.ChatRequestRepository;
 import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.notification.service.NotificationService;
 import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.repository.BlockRepository;
 import com.team.buddyya.student.service.FindStudentService;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @Transactional
@@ -30,6 +29,7 @@ public class ChatRequestService {
     private final ChatroomRepository chatroomRepository;
     private final FindStudentService findStudentService;
     private final NotificationService notificationService;
+    private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
     public List<ChatRequestResponse> getChatRequests(CustomUserDetails userDetails) {
@@ -40,14 +40,14 @@ public class ChatRequestService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
-    public ChatRequestInfoResponse getChatRequestInfo(CustomUserDetails userDetails, Long receiverId) {
-        Student sender = findStudentService.findByStudentId(userDetails.getStudentInfo().id());
-        Student receiver = findStudentService.findByStudentId(receiverId);
-        boolean isAlreadyExistChatRequest = isAlreadyExistChatRequest(sender, receiver);
-        boolean isAlreadyExistChatroom = isAlreadyExistChatroom(sender, receiver);
-        return ChatRequestInfoResponse.from(isAlreadyExistChatRequest, isAlreadyExistChatroom);
-    }
+//    @Transactional(readOnly = true)
+//    public ChatRequestInfoResponse getChatRequestInfo(CustomUserDetails userDetails, Long receiverId) {
+//        Student sender = findStudentService.findByStudentId(userDetails.getStudentInfo().id());
+//        Student receiver = findStudentService.findByStudentId(receiverId);
+//        boolean isAlreadyExistChatRequest = isAlreadyExistChatRequest(sender, receiver);
+//        boolean isAlreadyExistChatroom = isAlreadyExistChatroom(sender, receiver);
+//        return ChatRequestInfoResponse.from(isAlreadyExistChatRequest, isAlreadyExistChatroom);
+//    }
 
     @Transactional(readOnly = true)
     public boolean isAlreadyExistChatRequest(Student sender, Student receiver) {
@@ -57,7 +57,18 @@ public class ChatRequestService {
 
     @Transactional(readOnly = true)
     public boolean isAlreadyExistChatroom(Student sender, Student receiver) {
-        return chatroomRepository.findByUserAndBuddy(sender.getId(), receiver.getId()).isPresent();
+        boolean activeChatroomExists = chatroomRepository
+                .findLatestActiveChatroomByUserPair(sender.getId(), receiver.getId())
+                .isPresent();
+        if (activeChatroomExists) {
+            return false;
+        }
+        return true;
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isBlockedEachOther(Student sender, Long receiverId) {
+        return blockRepository.existsByBlockerAndBlockedStudentId(sender, receiverId);
     }
 
     public void createChatRequest(CustomUserDetails userDetails, Long receiverId) {
@@ -89,6 +100,9 @@ public class ChatRequestService {
         }
         if (isAlreadyExistChatRequest(sender, receiver)) {
             throw new ChatException(ChatExceptionType.CHAT_REQUEST_ALREADY_EXISTS);
+        }
+        if (isBlockedEachOther(sender, receiver.getId())) {
+            throw new ChatException(ChatExceptionType.CHATROOM_ALREADY_EXISTS);
         }
         if (isAlreadyExistChatroom(sender, receiver)) {
             throw new ChatException(ChatExceptionType.CHATROOM_ALREADY_EXISTS);

--- a/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
@@ -57,13 +57,9 @@ public class ChatRequestService {
 
     @Transactional(readOnly = true)
     public boolean isAlreadyExistChatroom(Student sender, Student receiver) {
-        boolean activeChatroomExists = chatroomRepository
+        return chatroomRepository
                 .findLatestActiveChatroomByUserPair(sender.getId(), receiver.getId())
                 .isPresent();
-        if (activeChatroomExists) {
-            return false;
-        }
-        return true;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
+++ b/src/main/java/com/team/buddyya/chatting/service/ChatRequestService.java
@@ -92,7 +92,7 @@ public class ChatRequestService {
             throw new ChatException(ChatExceptionType.CHAT_REQUEST_ALREADY_EXISTS);
         }
         if (isBlockedEachOther(sender, receiver.getId())) {
-            throw new ChatException(ChatExceptionType.CHATROOM_ALREADY_EXISTS);
+            throw new ChatException(ChatExceptionType.CHAT_REQUEST_BLOCKED);
         }
         if (isAlreadyExistChatroom(sender, receiver)) {
             throw new ChatException(ChatExceptionType.CHATROOM_ALREADY_EXISTS);

--- a/src/main/java/com/team/buddyya/feed/domain/Bookmark.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Bookmark.java
@@ -12,12 +12,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "bookmark")
+@Table(
+        name = "bookmark",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"feed_id", "student_id"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class Bookmark extends CreatedTime {

--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -47,6 +47,9 @@ public class Feed extends BaseTime {
     @Column(name = "view_count", nullable = false)
     private int viewCount;
 
+    @Column(name = "is_profile_visible", nullable = false)
+    private boolean isProfileVisible;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
@@ -72,21 +75,24 @@ public class Feed extends BaseTime {
     private List<Bookmark> bookmarks;
 
     @Builder
-    public Feed(String title, String content, Student student, Category category, University university) {
+    public Feed(String title, String content, Student student, Category category, University university,
+                boolean isProfileVisible) {
         this.title = title;
         this.content = content;
         this.student = student;
         this.category = category;
         this.university = university;
+        this.isProfileVisible = isProfileVisible;
         this.likeCount = 0;
         this.commentCount = 0;
         this.viewCount = 0;
     }
 
-    public void updateFeed(String title, String content, Category category) {
+    public void updateFeed(String title, String content, Category category, boolean isProfileVisible) {
         this.title = title;
         this.content = content;
         this.category = category;
+        this.isProfileVisible = isProfileVisible;
     }
 
     public void increaseLikeCount() {

--- a/src/main/java/com/team/buddyya/feed/domain/FeedLike.java
+++ b/src/main/java/com/team/buddyya/feed/domain/FeedLike.java
@@ -14,12 +14,18 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreRemove;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "feed_like")
+@Table(
+        name = "feed_like",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"feed_id", "student_id"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class FeedLike extends CreatedTime {

--- a/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedCreateRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedCreateRequest.java
@@ -8,6 +8,7 @@ public record FeedCreateRequest(
         String content,
         String university,
         String category,
+        boolean isProfileVisible,
         List<MultipartFile> images
 ) {
 }

--- a/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedUpdateRequest.java
+++ b/src/main/java/com/team/buddyya/feed/dto/request/feed/FeedUpdateRequest.java
@@ -1,13 +1,13 @@
 package com.team.buddyya.feed.dto.request.feed;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public record FeedUpdateRequest(
         String title,
         String content,
         String category,
+        boolean isProfileVisible,
         List<MultipartFile> images
 ) {
 }

--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -26,6 +26,7 @@ public record FeedResponse(
         boolean isLiked,
         boolean isBookmarked,
         boolean isProfileImageUpload,
+        boolean isProfileVisible,
         boolean isStudentDeleted,
         LocalDateTime createdDate
 ) {
@@ -54,6 +55,7 @@ public record FeedResponse(
                 userAction.isLiked(),
                 userAction.isBookmarked(),
                 isProfileImageUpload,
+                feed.isProfileVisible(),
                 feed.getStudent().getIsDeleted(),
                 feed.getCreatedDate()
         );

--- a/src/main/java/com/team/buddyya/feed/repository/BookmarkRepository.java
+++ b/src/main/java/com/team/buddyya/feed/repository/BookmarkRepository.java
@@ -3,7 +3,6 @@ package com.team.buddyya.feed.repository;
 import com.team.buddyya.feed.domain.Bookmark;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.student.domain.Student;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,8 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     Optional<Bookmark> findByStudentAndFeed(Student student, Feed feed);
-
-    List<Bookmark> findAllByStudentAndFeed(Student student, Feed feed);
 
     boolean existsByStudentAndFeed(Student student, Feed feed);
 

--- a/src/main/java/com/team/buddyya/feed/repository/BookmarkRepository.java
+++ b/src/main/java/com/team/buddyya/feed/repository/BookmarkRepository.java
@@ -3,6 +3,7 @@ package com.team.buddyya.feed.repository;
 import com.team.buddyya.feed.domain.Bookmark;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.student.domain.Student;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Repository;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     Optional<Bookmark> findByStudentAndFeed(Student student, Feed feed);
+
+    List<Bookmark> findAllByStudentAndFeed(Student student, Feed feed);
 
     boolean existsByStudentAndFeed(Student student, Feed feed);
 

--- a/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
+++ b/src/main/java/com/team/buddyya/feed/service/BookmarkService.java
@@ -10,6 +10,7 @@ import com.team.buddyya.feed.repository.BookmarkRepository;
 import com.team.buddyya.feed.repository.FeedRepository;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,14 +35,14 @@ public class BookmarkService {
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_BOOKMARKED));
     }
 
+    @Transactional
     public BookmarkResponse toggleBookmark(StudentInfo studentInfo, Long feedId) {
         Feed feed = feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
         Student student = findStudentService.findByStudentId(studentInfo.id());
-        boolean isBookmarked = existsByStudentAndFeed(student, feed);
-        if (isBookmarked) {
-            Bookmark bookmark = findByStudentAndFeed(student, feed);
-            bookmarkRepository.delete(bookmark);
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByStudentAndFeed(student, feed);
+        if (!bookmarks.isEmpty()) {
+            bookmarkRepository.deleteAll(bookmarks);
             return BookmarkResponse.from(false);
         }
         Bookmark bookmark = Bookmark.builder()

--- a/src/main/java/com/team/buddyya/feed/service/FeedLikeService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedLikeService.java
@@ -11,6 +11,7 @@ import com.team.buddyya.feed.repository.FeedRepository;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,7 +49,11 @@ public class FeedLikeService {
                 .feed(feed)
                 .student(student)
                 .build();
-        feedLikeRepository.save(feedLike);
-        return LikeResponse.from(true, feed.getLikeCount());
+        try {
+            feedLikeRepository.save(feedLike);
+            return LikeResponse.from(true, feed.getLikeCount());
+        } catch (DataIntegrityViolationException e) {
+            return LikeResponse.from(true, feed.getLikeCount());
+        }
     }
 }

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -1,7 +1,13 @@
 package com.team.buddyya.feed.service;
 
+import static com.team.buddyya.student.domain.Role.ADMIN;
+
 import com.team.buddyya.auth.domain.StudentInfo;
-import com.team.buddyya.feed.domain.*;
+import com.team.buddyya.feed.domain.Bookmark;
+import com.team.buddyya.feed.domain.Category;
+import com.team.buddyya.feed.domain.Feed;
+import com.team.buddyya.feed.domain.FeedImage;
+import com.team.buddyya.feed.domain.FeedUserAction;
 import com.team.buddyya.feed.dto.request.feed.FeedCreateRequest;
 import com.team.buddyya.feed.dto.request.feed.FeedListRequest;
 import com.team.buddyya.feed.dto.request.feed.FeedUpdateRequest;
@@ -21,6 +27,8 @@ import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.BlockRepository;
 import com.team.buddyya.student.repository.UniversityRepository;
 import com.team.buddyya.student.service.FindStudentService;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,11 +37,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.Set;
-
-import static com.team.buddyya.student.domain.Role.ADMIN;
 
 @Service
 @Transactional
@@ -160,6 +163,7 @@ public class FeedService {
                 .student(student)
                 .category(category)
                 .university(university)
+                .isProfileVisible(request.isProfileVisible())
                 .build();
         feedRepository.save(feed);
         uploadImages(feed, request.images());
@@ -169,7 +173,7 @@ public class FeedService {
         Feed feed = findFeedByFeedId(feedId);
         validateFeedOwner(studentInfo, feed);
         Category category = categoryService.getCategory(request.category());
-        feed.updateFeed(request.title(), request.content(), category);
+        feed.updateFeed(request.title(), request.content(), category, request.isProfileVisible());
         updateImages(feed, request.images());
     }
 

--- a/src/main/resources/db/migration/V23__Add_is_profile_visible_to_feed.sql
+++ b/src/main/resources/db/migration/V23__Add_is_profile_visible_to_feed.sql
@@ -1,0 +1,2 @@
+ALTER TABLE feed
+    ADD COLUMN is_profile_visible BOOLEAN NOT NULL DEFAULT false;

--- a/src/main/resources/db/migration/V24__Update_bookmark_unique_feed_student.sql
+++ b/src/main/resources/db/migration/V24__Update_bookmark_unique_feed_student.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bookmark
+    ADD CONSTRAINT uq_bookmark_feed_student UNIQUE (feed_id, student_id);

--- a/src/main/resources/db/migration/V25__Update_feedLike_unique_feed_student.sql
+++ b/src/main/resources/db/migration/V25__Update_feedLike_unique_feed_student.sql
@@ -1,0 +1,2 @@
+ALTER TABLE feed_like
+    ADD CONSTRAINT uq_feed_like_feed_student UNIQUE (feed_id, student_id);


### PR DESCRIPTION
## 📌 관련 이슈
[피드에서 채팅 요청 시 로직 개선 #305](https://github.com/buddy-ya/be/issues/305)

## 🛠️ 작업 내용
- **채팅 요청 생성 로직 변경**  
  - 차단 관계가 존재하거나, 두 사용자 간의 가장 최근 채팅방이 active 상태(둘 다 채팅방에 남아 있는 상태)인 경우에만 채팅 요청 생성이 불가하도록 개선했습니다.
- **북마크 중복 저장 방지**  
  - 동일 학생-피드 조합의 북마크가 여러 건 저장되지 않도록 DB 테이블에 (feed_id, student_id) 복합 유니크 제약 조건을 추가하고자 하였으나, 기존에 엔티티에 제약 조건을 건 사례가 없어 서비스 로직에서 이를 개선하고자 하였습니다. (논의가 필요합니다.)
  - 서비스 로직에서 북마크 토글 시 피드-학생 조건에 해당하는 모든 북마크를 조회하여 삭제 후 처리하도록 개선했습니다.
- **피드 생성 시 프로필 공개 여부 포함**  
  - 피드 생성 시 사용자가 프로필을 공개할지 여부(예: `is_profile_visible`)를 설정할 수 있도록 엔티티 및 마이그레이션 스크립트를 추가했습니다.

## 🎯 리뷰 포인트
- **채팅 요청 생성 로직**  
  - 현재 차단 관계 및 최근 채팅방의 active 상태 검사에 대해 추가로 고려할 사항은 없는지 검토해 주세요.
- **북마크 중복 저장 문제**  
  - 북마크를 빠르게 연타할 경우 중복 저장되는 현상을 DB의 UNIQUE 제약 조건으로 해결하는 방법을 적용해도 될지 알려주세요. 혹은 서비스 로직만으로 괜찮을까요?
- **피드 생성 시 프로필 공개 여부**  
  - 프로필 공개 여부 필드의 네이밍(`is_profile_visible`)과 마이그레이션 스크립트가 적절한지 확인해 주세요.

## 🤔 고민한 점
- **채팅 요청 생성 로직 검사 JPQL이 최선인가**  
현재 채팅 요청 생성 시, 두 사용자의 최근 채팅방이 active 상태(둘 중 하나라도 나가지 않은 상태)인지를 검사하기 위해 아래와 같은 JPQL을 사용하고 있습니다.
```
    @Query("SELECT c FROM Chatroom c " +
            "JOIN c.chatroomStudents cs " +
            "WHERE cs.student.id IN (:senderId, :receiverId) " +
            "  AND cs.isExited = false " +
            "GROUP BY c.id " +
            "HAVING COUNT(cs) = 2 " +
            "ORDER BY c.lastMessageTime DESC")
```
순수 CRUD Repository를 사용하지 않은 이유는
1. `chatroomStudent`에서 두 유저가 포함된 가장 최신의 `chatroomStudent` 불러오기.
2. 해당 row에 대하여 `chatroomStudent`에서 각 유저가 둘 다 나가지 않은 상태인지 확인.
=> 복잡합니다.

더 쉽게 풀이할 수 있는 방법이 있다면, 의견 공유 해주시면 감사하겠습니다.

