### PR TITLE
refactor: 매칭 알림 본문 개선 및 포인트 변화 시 현재 포인트 포함

### DIFF
--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -18,6 +18,7 @@ import com.team.buddyya.chatting.repository.ChatRepository;
 import com.team.buddyya.chatting.repository.ChatroomRepository;
 import com.team.buddyya.common.service.S3UploadService;
 import com.team.buddyya.notification.service.NotificationService;
+import com.team.buddyya.point.domain.Point;
 import com.team.buddyya.point.domain.PointType;
 import com.team.buddyya.point.service.UpdatePointService;
 import com.team.buddyya.report.domain.Report;
@@ -142,8 +143,8 @@ public class AdminService {
                 .orElseThrow(() -> new ChatException(ChatExceptionType.CHATROOM_NOT_FOUND));
         if (chatroom.getType().equals(ChatroomType.MATCHING)) {
             Student reportUser = findStudentService.findByStudentId(reportUserId);
-            updatePointService.updatePoint(reportUser, PointType.CHATROOM_NO_RESPONSE_REFUND);
-            notificationService.sendRefundNotification(reportUser);
+            Point point = updatePointService.updatePoint(reportUser, PointType.CHATROOM_NO_RESPONSE_REFUND);
+            notificationService.sendRefundNotification(point, reportUser);
         }
     }
 }

--- a/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
+++ b/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
@@ -230,7 +230,8 @@ public class BasicMatchService implements MatchService {
         matchRequest.updateChatroomId(chatroom.getId());
         MatchingProfile matchingProfile = matchingProfileRepository.findByStudent(matchedStudent)
                 .orElseThrow(() -> new MatchException(MatchExceptionType.MATCH_PROFILE_NOT_FOUND));
-        notificationService.sendMatchSuccessNotification(matchedStudent, student, chatroom, newMatchRequest, point, false, matchingProfile);
+        notificationService.sendMatchSuccessNotification(student, chatroom.getId());
+        notificationService.sendPendingMatchSuccessNotification(matchedStudent, student, chatroom, newMatchRequest, point, false, matchingProfile);
         log.info("🤝 Successfully matched: [{}] ↔ [{}]", student.getId(), matchedStudent.getId());
         return MatchResponse.from(chatroom, matchedStudent, newMatchRequest, point, false, matchingProfile);
     }

--- a/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
+++ b/src/main/java/com/team/buddyya/match/service/BasicMatchService.java
@@ -228,10 +228,9 @@ public class BasicMatchService implements MatchService {
         MatchRequest newMatchRequest = createMatchRequest(student, false, chatroom.getId(), nationalityType, universityType, genderType, MatchRequestStatus.MATCH_SUCCESS);
         matchRequest.updateMatchRequestStatusSuccess();
         matchRequest.updateChatroomId(chatroom.getId());
-        notificationService.sendMatchSuccessNotification(student, chatroom.getId());
-        notificationService.sendMatchSuccessNotification(matchedStudent, chatroom.getId());
         MatchingProfile matchingProfile = matchingProfileRepository.findByStudent(matchedStudent)
                 .orElseThrow(() -> new MatchException(MatchExceptionType.MATCH_PROFILE_NOT_FOUND));
+        notificationService.sendMatchSuccessNotification(matchedStudent, student, chatroom, newMatchRequest, point, false, matchingProfile);
         log.info("🤝 Successfully matched: [{}] ↔ [{}]", student.getId(), matchedStudent.getId());
         return MatchResponse.from(chatroom, matchedStudent, newMatchRequest, point, false, matchingProfile);
     }

--- a/src/main/java/com/team/buddyya/notification/domain/RequestNotification.java
+++ b/src/main/java/com/team/buddyya/notification/domain/RequestNotification.java
@@ -17,15 +17,17 @@ public class RequestNotification {
     private String body;
     private String priority;
     private String channelId;
+    private String sound;
     private Map<String, Object> data;
 
     @Builder
-    public RequestNotification(String to, String title, String body, Map<String, Object> data, String priority, String channelId) {
+    public RequestNotification(String to, String title, String body, Map<String, Object> data) {
         this.to = to;
         this.title = title;
         this.body = body;
         this.data = data;
-        this.priority = priority;
-        this.channelId = channelId;
+        this.priority = "high";
+        this.sound = "default";
+        this.channelId = ("default");
     }
 }

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -9,6 +9,7 @@ import com.team.buddyya.notification.dto.response.SaveTokenResponse;
 import com.team.buddyya.notification.exception.NotificationException;
 import com.team.buddyya.notification.exception.NotificationExceptionType;
 import com.team.buddyya.notification.repository.ExpoTokenRepository;
+import com.team.buddyya.point.domain.Point;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.service.FindStudentService;
 import lombok.RequiredArgsConstructor;
@@ -330,14 +331,15 @@ public class NotificationService {
         return isKorean ? CHAT_ACCEPT_BODY_KR : CHAT_ACCEPT_BODY_EN;
     }
 
-    public void sendInvitationRewardNotification(Student student) {
+    public void sendInvitationRewardNotification(Point point, Student student) {
         try {
             String token = getTokenByUserId(student.getId());
             boolean isKorean = student.getIsKorean();
             String title = isKorean ? INVITATION_REWARD_TITLE_KR : INVITATION_REWARD_TITLE_EN;
             String body = isKorean ? INVITATION_REWARD_BODY_KR : INVITATION_REWARD_BODY_EN;
             Map<String, Object> data = Map.of(
-                    "type", "POINT"
+                    "type", "POINT",
+                    "point", point.getCurrentPoint()
             );
             sendToExpo(RequestNotification.builder()
                     .to(token)
@@ -353,14 +355,15 @@ public class NotificationService {
         }
     }
 
-    public void sendRefundNotification(Student student) {
+    public void sendRefundNotification(Point point, Student student) {
         try {
             String token = getTokenByUserId(student.getId());
             boolean isKorean = student.getIsKorean();
             String title = isKorean ? REFUND_POINTS_TITLE_KR : REFUND_POINTS_TITLE_EN;
             String body = isKorean ? REFUND_POINTS_BODY_KR : REFUND_POINTS_BODY_EN;
             Map<String, Object> data = Map.of(
-                    "type", "POINT"
+                    "type", "POINT",
+                    "point", point.getCurrentPoint()
             );
             sendToExpo(RequestNotification.builder()
                     .to(token)
@@ -376,14 +379,15 @@ public class NotificationService {
         }
     }
 
-    public void sendDailyAttendanceNotification(Student student) {
+    public void sendDailyAttendanceNotification(Point point, Student student) {
         try {
             String token = getTokenByUserId(student.getId());
             boolean isKorean = student.getIsKorean();
             String title = isKorean ? ATTENDANCE_REWARD_TITLE_KR : ATTENDANCE_REWARD_TITLE_EN;
             String body = isKorean ? ATTENDANCE_REWARD_BODY_KR : ATTENDANCE_REWARD_BODY_EN;
             Map<String, Object> data = Map.of(
-                    "type", "POINT"
+                    "type", "POINT",
+                    "point", point.getCurrentPoint()
             );
             sendToExpo(RequestNotification.builder()
                     .to(token)

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -156,8 +156,6 @@ public class NotificationService {
                     .to(token)
                     .title(title)
                     .body(body)
-                    .priority("high")
-                    .channelId("default")
                     .data(data).build()
             );
         } catch (NotificationException e) {
@@ -190,8 +188,6 @@ public class NotificationService {
                         .to(token)
                         .title(title)
                         .body(commentContent)
-                        .priority("high")
-                        .channelId("default")
                         .data(data).build()
                 );
             } catch (NotificationException e) {
@@ -220,8 +216,6 @@ public class NotificationService {
                         .to(token)
                         .title(title)
                         .body(commentContent)
-                        .priority("high")
-                        .channelId("default")
                         .data(data).build()
                 );
             } catch (NotificationException e) {
@@ -255,8 +249,6 @@ public class NotificationService {
                 .to(token)
                 .title(title)
                 .body(body)
-                .priority("high")
-                .channelId("default")
                 .data(data)
                 .build();
     }
@@ -304,8 +296,6 @@ public class NotificationService {
                     .to(token)
                     .title(title)
                     .body(body)
-                    .priority("high")
-                    .channelId("default")
                     .data(data)
                     .build()
             );
@@ -338,8 +328,6 @@ public class NotificationService {
                     .to(token)
                     .title(title)
                     .body(body)
-                    .priority("high")
-                    .channelId("default")
                     .data(data).build()
             );
         } catch (NotificationException e) {
@@ -369,8 +357,6 @@ public class NotificationService {
                     .to(token)
                     .title(title)
                     .body(body)
-                    .priority("high")
-                    .channelId("default")
                     .data(data)
                     .build()
             );
@@ -393,8 +379,6 @@ public class NotificationService {
                     .to(token)
                     .title(title)
                     .body(body)
-                    .priority("high")
-                    .channelId("default")
                     .data(data)
                     .build()
             );
@@ -417,8 +401,6 @@ public class NotificationService {
                     .to(token)
                     .title(title)
                     .body(body)
-                    .priority("high")
-                    .channelId("default")
                     .data(data)
                     .build()
             );

--- a/src/main/java/com/team/buddyya/student/service/InvitationService.java
+++ b/src/main/java/com/team/buddyya/student/service/InvitationService.java
@@ -52,11 +52,11 @@ public class InvitationService {
         Student requestedStudent = findStudentService.findByStudentId(studentInfo.id());
         RegisteredPhone requestedPhone = findRegisteredPhone(requestedStudent.getPhoneNumber());
         validateNotAlreadyParticipated(requestedPhone);
-        Point point = updatePointService.updatePoint(requestedStudent, PointType.INVITATION_EVENT);
-        updatePointService.updatePoint(invitingStudent, PointType.INVITATION_EVENT);
-        notificationService.sendInvitationRewardNotification(invitingStudent);
+        Point requestedStudentPoint = updatePointService.updatePoint(requestedStudent, PointType.INVITATION_EVENT);
+        Point invitingStudentPoint = updatePointService.updatePoint(invitingStudent, PointType.INVITATION_EVENT);
+        notificationService.sendInvitationRewardNotification(invitingStudentPoint, invitingStudent);
         requestedPhone.markAsInvitationEventParticipated();
-        return ValidateInvitationCodeResponse.from(point, PointType.INVITATION_EVENT);
+        return ValidateInvitationCodeResponse.from(requestedStudentPoint, PointType.INVITATION_EVENT);
     }
 
     private Student validateAndFindInvitingStudent(Long requestedStudentId, String code) {

--- a/src/main/java/com/team/buddyya/student/service/StudentService.java
+++ b/src/main/java/com/team/buddyya/student/service/StudentService.java
@@ -248,9 +248,9 @@ public class StudentService {
         RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
                 .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));
         if (!registeredPhone.isTodayAlreadyChecked()) {
-            updatePointService.updatePoint(student, PointType.EVENT_REWARD);
+            Point point = updatePointService.updatePoint(student, PointType.EVENT_REWARD);
             registeredPhone.updateLastAttendanceDateToToday();
-            notificationService.sendDailyAttendanceNotification(student);
+            notificationService.sendDailyAttendanceNotification(point, student);
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
[매칭 알림 본문 개선 및 포인트 변화 시 현재 포인트 포함](https://github.com/buddy-ya/be/issues/307)[#307]

<br><br>

## 🛠️ 작업 내용
- 매칭 알림 본문 개선
- 포인트 변화 시 현재 포인트 포함

<br><br>

## 🎯 리뷰 포인트
- 즉시 매칭된 유저에게 알림을 전송해야될까?

<br><br>

## 📎 커밋 범위 링크

<br><br>
