### PR TITLE
fix: 이미지 url 깨지는 문제 수정

### DIFF
--- a/src/main/java/com/team/buddyya/common/service/S3UploadService.java
+++ b/src/main/java/com/team/buddyya/common/service/S3UploadService.java
@@ -20,6 +20,7 @@ public class S3UploadService {
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
+
     @Value("${cloud.aws.s3.url}")
     private String defaultUrl;
 
@@ -44,8 +45,19 @@ public class S3UploadService {
     }
 
     private String generateFileName(MultipartFile file) {
-        String fileName = UUID.randomUUID().toString() + "-" + file.getOriginalFilename();
-        return fileName.replaceAll("[\\s,]", "_");
+        String extension = getFileExtension(file.getOriginalFilename());
+        return UUID.randomUUID().toString() + (extension.isEmpty() ? "" : "." + extension);
+    }
+
+    private String getFileExtension(String originalName) {
+        if (originalName == null) {
+            return "";
+        }
+        int dotIndex = originalName.lastIndexOf('.');
+        if (dotIndex == -1 || dotIndex == originalName.length() - 1) {
+            return "";
+        }
+        return originalName.substring(dotIndex + 1).toLowerCase();
     }
 
     public void deleteFile(String dir, String fileUrl) {


### PR DESCRIPTION
## 📌 관련 이슈
[s3 일부 이미지 url이 깨지는 오류 [#317]](https://github.com/buddy-ya/be/issues/317)
<br><br>

## 🛠️ 작업 내용
- 공백이 포함된 이미지 url 인코딩이 잘 되지 않는 문제 수정
- 기존에는 이미지 url을 UUID + 이미지명 변환을 하여 저장했지만 이미지명 변환 시 문제가 발생하여 UUID만을 활용하여 url을 저장하였습니다
<br><br>

## 🎯 리뷰 포인트
- 이미지 url 변환 로직이 적절한가?
<br><br>

## 📎 커밋 범위 링크

<br><br>
