### PR TITLE
refactor: 상대방 프로필 조회시 인증 여부 추가

### DIFF
--- a/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
@@ -78,7 +78,7 @@ public record UserResponse(
                 student.getUniversity().getUniversityName(),
                 student.getGender().getDisplayName(),
                 getChatroomProfileImage(student),
-                null,
+                student.getIsCertificated(),
                 null,
                 null,
                 isDefaultUserProfileImage(student),


### PR DESCRIPTION
## 📌 관련 이슈
[상대 프로필 조회시 인증 여부 반환](https://github.com/buddy-ya/be/issues/328)

<br><br>

## 🛠️ 작업 내용
- 상대 프로필 조회(`getUserInfo` -> fromOtherUserInfo) 에 isCertificated 값 추가해서 반환

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
