### PR TITLE
기존 회원가입 포인트 정책 개선 및 인증 미션 도입

### DIFF
--- a/src/main/java/com/team/buddyya/admin/dto/response/StudentVerificationResponse.java
+++ b/src/main/java/com/team/buddyya/admin/dto/response/StudentVerificationResponse.java
@@ -1,4 +1,11 @@
 package com.team.buddyya.admin.dto.response;
 
-public record StudentVerificationResponse(String message) {
+import com.team.buddyya.point.domain.Point;
+import com.team.buddyya.point.domain.PointType;
+
+public record StudentVerificationResponse(Integer point, Integer pointChange) {
+
+    public static StudentVerificationResponse from(Point point, PointType pointType) {
+        return new StudentVerificationResponse(point.getCurrentPoint(), pointType.getPointChange());
+    }
 }

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -98,14 +98,14 @@ public class AdminService {
         if (!registeredPhone.getHasCertificated()) {
             Point updatedPoint = updatePointService.updatePoint(student, PointType.MISSION_CERTIFICATION_REWARD);
             registeredPhone.updateHasCertificated();
-            notificationService.sendAuthorizationNotification(student, updatedPoint,true);
+            notificationService.sendAuthorizationNotification(student, updatedPoint, true);
             return StudentVerificationResponse.from(point, PointType.MISSION_CERTIFICATION_REWARD);
         }
-        notificationService.sendAuthorizationNotification(student, point,true);
+        notificationService.sendAuthorizationNotification(student, point, true);
         return StudentVerificationResponse.from(point, PointType.NO_POINT_CHANGE);
     }
 
-    private StudentVerificationResponse rejectStudentIdCard(StudentVerificationRequest request,Point point, StudentIdCard studentIdCard, Student student) {
+    private StudentVerificationResponse rejectStudentIdCard(StudentVerificationRequest request, Point point, StudentIdCard studentIdCard, Student student) {
         studentIdCard.updateRejectionReason(request.rejectionReason());
         notificationService.sendAuthorizationNotification(student, point, false);
         return StudentVerificationResponse.from(point, PointType.NO_POINT_CHANGE);

--- a/src/main/java/com/team/buddyya/admin/service/AdminService.java
+++ b/src/main/java/com/team/buddyya/admin/service/AdminService.java
@@ -99,7 +99,7 @@ public class AdminService {
             Point updatedPoint = updatePointService.updatePoint(student, PointType.MISSION_CERTIFICATION_REWARD);
             registeredPhone.updateHasCertificated();
             notificationService.sendAuthorizationNotification(student, updatedPoint, true);
-            return StudentVerificationResponse.from(point, PointType.MISSION_CERTIFICATION_REWARD);
+            return StudentVerificationResponse.from(updatedPoint, PointType.MISSION_CERTIFICATION_REWARD);
         }
         notificationService.sendAuthorizationNotification(student, point, true);
         return StudentVerificationResponse.from(point, PointType.NO_POINT_CHANGE);

--- a/src/main/java/com/team/buddyya/certification/controller/CertificationController.java
+++ b/src/main/java/com/team/buddyya/certification/controller/CertificationController.java
@@ -29,26 +29,27 @@ public class CertificationController {
     private final EmailSendService emailSendService;
 
     @PostMapping("/email/send")
-    public ResponseEntity<CertificationResponse> sendEmail(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public ResponseEntity<Void> sendEmail(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                            @RequestBody EmailCertificationRequest emailCertificationRequest) {
 
         String generatedCode = emailSendService.sendEmail(userDetails.getStudentInfo(), emailCertificationRequest);
-        CertificationResponse response = certificationService.saveCode(emailCertificationRequest.email(), generatedCode);
-        return ResponseEntity.ok(response);
+        certificationService.saveCode(emailCertificationRequest.email(), generatedCode);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/email/verify-code")
     public ResponseEntity<CertificationResponse> emailCodeCertificate(
             @AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody EmailCodeRequest codeRequest) {
-        return ResponseEntity.ok(certificationService.certificateEmailCode(userDetails.getStudentInfo(), codeRequest));
+        CertificationResponse response = certificationService.certificateEmailCode(userDetails.getStudentInfo(), codeRequest);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/student-id-card")
-    public ResponseEntity<CertificationResponse> sendStudentIdCard(
+    public ResponseEntity<Void> sendStudentIdCard(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @ModelAttribute SendStudentIdCardRequest sendStudentIdCardRequest) {
-        return ResponseEntity.ok(
-                certificationService.uploadStudentIdCard(userDetails.getStudentInfo(), sendStudentIdCardRequest));
+        certificationService.uploadStudentIdCard(userDetails.getStudentInfo(), sendStudentIdCardRequest);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/student-id-card")

--- a/src/main/java/com/team/buddyya/certification/domain/RegisteredPhone.java
+++ b/src/main/java/com/team/buddyya/certification/domain/RegisteredPhone.java
@@ -36,6 +36,9 @@ public class RegisteredPhone extends CreatedTime {
     @Column(name = "has_withdrawn", nullable = false)
     private Boolean hasWithdrawn;
 
+    @Column(name = "has_certificated", nullable = false)
+    private Boolean hasCertificated;
+
     @Column(name = "last_attendance_date")
     private LocalDate lastAttendanceDate;
 
@@ -46,6 +49,7 @@ public class RegisteredPhone extends CreatedTime {
         this.invitationCode = invitationCode;
         this.invitationEventParticipated = false;
         this.hasWithdrawn = false;
+        this.hasCertificated = false;
         lastAttendanceDate = null;
     }
 
@@ -66,5 +70,9 @@ public class RegisteredPhone extends CreatedTime {
 
     public void updateLastAttendanceDateToToday() {
         this.lastAttendanceDate = LocalDate.now();
+    }
+
+    public void updateHasCertificated() {
+        this.hasCertificated = true;
     }
 }

--- a/src/main/java/com/team/buddyya/certification/dto/response/CertificationResponse.java
+++ b/src/main/java/com/team/buddyya/certification/dto/response/CertificationResponse.java
@@ -1,8 +1,11 @@
 package com.team.buddyya.certification.dto.response;
 
-public record CertificationResponse(boolean success) {
+import com.team.buddyya.point.domain.Point;
+import com.team.buddyya.point.domain.PointType;
 
-    public static CertificationResponse from(boolean success) {
-        return new CertificationResponse(success);
+public record CertificationResponse(Integer point, Integer pointChange) {
+
+    public static CertificationResponse from(Point point, PointType pointType) {
+        return new CertificationResponse(point.getCurrentPoint(), pointType.getPointChange());
     }
 }

--- a/src/main/java/com/team/buddyya/mission/controller/MissionController.java
+++ b/src/main/java/com/team/buddyya/mission/controller/MissionController.java
@@ -1,0 +1,33 @@
+package com.team.buddyya.mission.controller;
+
+import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.mission.service.MissionService;
+import com.team.buddyya.mission.dto.PointMissionResponse;
+import com.team.buddyya.mission.dto.PointMissionRewardResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/missions")
+@RequiredArgsConstructor
+public class MissionController {
+
+    private final MissionService missionService;
+
+    @GetMapping
+    public ResponseEntity<PointMissionResponse> getUserMissionInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
+        PointMissionResponse response = missionService.getUserMissionInfo(userDetails.getStudentInfo());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/attendance")
+    public ResponseEntity<PointMissionRewardResponse> rewardVisitPoint(@AuthenticationPrincipal CustomUserDetails userDetails){
+        PointMissionRewardResponse response = missionService.checkAttendanceAndReward(userDetails.getStudentInfo());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/team/buddyya/mission/dto/PointMissionResponse.java
+++ b/src/main/java/com/team/buddyya/mission/dto/PointMissionResponse.java
@@ -1,7 +1,6 @@
-package com.team.buddyya.point.dto;
+package com.team.buddyya.mission.dto;
 
 import com.team.buddyya.certification.domain.RegisteredPhone;
-import com.team.buddyya.student.domain.Student;
 
 public record PointMissionResponse(
         boolean hasCertificated,

--- a/src/main/java/com/team/buddyya/mission/dto/PointMissionRewardResponse.java
+++ b/src/main/java/com/team/buddyya/mission/dto/PointMissionRewardResponse.java
@@ -1,4 +1,4 @@
-package com.team.buddyya.point.dto;
+package com.team.buddyya.mission.dto;
 
 public record PointMissionRewardResponse(
         Integer currentPoint,

--- a/src/main/java/com/team/buddyya/mission/service/MissionService.java
+++ b/src/main/java/com/team/buddyya/mission/service/MissionService.java
@@ -1,0 +1,61 @@
+package com.team.buddyya.mission.service;
+
+import com.team.buddyya.auth.domain.StudentInfo;
+import com.team.buddyya.certification.domain.RegisteredPhone;
+import com.team.buddyya.certification.exception.PhoneAuthenticationException;
+import com.team.buddyya.certification.exception.PhoneAuthenticationExceptionType;
+import com.team.buddyya.certification.repository.RegisteredPhoneRepository;
+import com.team.buddyya.point.domain.Point;
+import com.team.buddyya.point.domain.PointChangeType;
+import com.team.buddyya.point.domain.PointStatus;
+import com.team.buddyya.point.domain.PointType;
+import com.team.buddyya.mission.dto.PointMissionResponse;
+import com.team.buddyya.mission.dto.PointMissionRewardResponse;
+import com.team.buddyya.point.repository.PointStatusRepository;
+import com.team.buddyya.point.service.FindPointService;
+import com.team.buddyya.point.service.UpdatePointService;
+import com.team.buddyya.student.domain.Student;
+import com.team.buddyya.student.service.FindStudentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MissionService {
+
+    private final UpdatePointService updatePointService;
+    private final PointStatusRepository pointStatusRepository;
+    private final FindPointService findPointService;
+    private final FindStudentService findStudentService;
+    private final RegisteredPhoneRepository registeredPhoneRepository;
+
+    public PointMissionResponse getUserMissionInfo(StudentInfo studentInfo){
+        Student student = findStudentService.findByStudentId(studentInfo.id());
+        RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
+                .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));
+        Point point = findPointService.findByStudent(student);
+        int totalMissionPoint = getTotalMissionPoint(point);
+        return PointMissionResponse.from(registeredPhone, totalMissionPoint);
+    }
+
+    public PointMissionRewardResponse checkAttendanceAndReward(StudentInfo studentInfo) {
+        Student student = findStudentService.findByStudentId(studentInfo.id());
+        RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
+                .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));
+        if (registeredPhone.isTodayAttended()) {
+            return PointMissionRewardResponse.from(null, PointType.NO_POINT_CHANGE.getPointChange());
+        }
+        Point point = updatePointService.updatePoint(student, PointType.MISSION_VISIT_REWARD);
+        registeredPhone.updateLastAttendanceDateToToday();
+        return PointMissionRewardResponse.from(point.getCurrentPoint(), PointType.MISSION_VISIT_REWARD.getPointChange());
+    }
+
+    public int getTotalMissionPoint(Point point) {
+        return pointStatusRepository.findAllByPointOrderByCreatedDateDesc(point).stream()
+                .filter(ps -> ps.getPointType().getChangeType() == PointChangeType.MISSION)
+                .mapToInt(PointStatus::getChangedPoint)
+                .sum();
+    }
+}

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -245,12 +245,13 @@ public class NotificationService {
         return isKorean ? FEED_TITLE_KR : FEED_TITLE_EN;
     }
 
-    public void sendAuthorizationNotification(Student student, boolean isSuccess) {
+    public void sendAuthorizationNotification(Student student, Point point, boolean isSuccess) {
         try {
             String token = getTokenByUserId(student.getId());
             Map<String, Object> data = new HashMap<>();
             data.put("type", "AUTHORIZATION");
             data.put("isCertificated", isSuccess);
+            data.put("point",point.getCurrentPoint());
             boolean isKorean = student.getIsKorean();
             RequestNotification notification = createAuthorizationNotification(isKorean, isSuccess, token, data);
             sendToExpo(notification);

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -120,12 +120,12 @@ public class NotificationService {
         expoTokenRepository.save(Token);
     }
 
-    public void sendMatchSuccessNotification(Student student, Long roomId){
-        try{
+    public void sendMatchSuccessNotification(Student student, Long roomId) {
+        try {
             String token = getTokenByUserId(student.getId());
             Map<String, Object> data = Map.of(
                     "roomId", roomId,
-                    "wasPending",false,
+                    "wasPending", false,
                     "type", "MATCH"
             );
             boolean isKorean = student.getIsKorean();
@@ -142,8 +142,8 @@ public class NotificationService {
         }
     }
 
-    public void sendPendingMatchSuccessNotification(Student student, Student buddy, Chatroom chatroom, MatchRequest matchRequest, Point point, boolean isExited, MatchingProfile matchingProfile){
-        try{
+    public void sendPendingMatchSuccessNotification(Student student, Student buddy, Chatroom chatroom, MatchRequest matchRequest, Point point, boolean isExited, MatchingProfile matchingProfile) {
+        try {
             String token = getTokenByUserId(student.getId());
             Map<String, Object> data = Map.ofEntries(
                     Map.entry("id", matchRequest.getId()),
@@ -163,7 +163,7 @@ public class NotificationService {
                     Map.entry("introduction", matchingProfile.getIntroduction()),
                     Map.entry("buddyActivity", matchingProfile.getBuddyActivity()),
                     Map.entry("isExited", isExited),
-                    Map.entry("wasPending",true),
+                    Map.entry("wasPending", true),
                     Map.entry("type", "MATCH")
             );
             boolean isKorean = student.getIsKorean();
@@ -181,17 +181,17 @@ public class NotificationService {
     }
 
     private String getMatchSuccessNotificationTitle(boolean isKorean) {
-        return isKorean ? MATCH_SUCCESS_TITLE_KR: MATCH_SUCCESS_TITLE_EN;
+        return isKorean ? MATCH_SUCCESS_TITLE_KR : MATCH_SUCCESS_TITLE_EN;
     }
 
     private String getMatchSuccessNotificationBody(boolean isKorean) {
-        return isKorean ? MATCH_SUCCESS_BODY_KR: MATCH_SUCCESS_BODY_EN;
+        return isKorean ? MATCH_SUCCESS_BODY_KR : MATCH_SUCCESS_BODY_EN;
     }
 
-    public void sendCommentReplyNotification(Long writerId, Feed feed, Comment parent, String commentContent){
+    public void sendCommentReplyNotification(Long writerId, Feed feed, Comment parent, String commentContent) {
         boolean isWriterParent = parent.isParent(writerId);
         boolean isParentFeedOwner = parent.isParent(feed.getStudent().getId());
-        if(!isWriterParent && !isParentFeedOwner) {
+        if (!isWriterParent && !isParentFeedOwner) {
             try {
                 Student recipient = parent.getStudent();
                 String token = getTokenByUserId(recipient.getId());
@@ -214,12 +214,12 @@ public class NotificationService {
     }
 
     private String getCommentReplyNotificationTitle(boolean isKorean) {
-        return isKorean ? FEED_REPLY_TITLE_KR: FEED_REPLY_TITLE_EN;
+        return isKorean ? FEED_REPLY_TITLE_KR : FEED_REPLY_TITLE_EN;
     }
 
     public void sendCommentNotification(Long writerId, Feed feed, String commentContent) {
         boolean isFeedOwner = feed.isFeedOwner(writerId);
-        if(!isFeedOwner) {
+        if (!isFeedOwner) {
             try {
                 Student recipient = feed.getStudent();
                 String token = getTokenByUserId(recipient.getId());
@@ -251,7 +251,7 @@ public class NotificationService {
             Map<String, Object> data = new HashMap<>();
             data.put("type", "AUTHORIZATION");
             data.put("isCertificated", isSuccess);
-            data.put("point",point.getCurrentPoint());
+            data.put("point", point.getCurrentPoint());
             boolean isKorean = student.getIsKorean();
             RequestNotification notification = createAuthorizationNotification(isKorean, isSuccess, token, data);
             sendToExpo(notification);
@@ -332,8 +332,8 @@ public class NotificationService {
                 : senderName + CHAT_REQUEST_BODY_EN;
     }
 
-    public void sendChatAcceptNotification(Student student, String senderName, Long roomId){
-        try{
+    public void sendChatAcceptNotification(Student student, String senderName, Long roomId) {
+        try {
             String token = getTokenByUserId(student.getId());
             Map<String, Object> data = Map.of(
                     "roomId", roomId,

--- a/src/main/java/com/team/buddyya/point/controller/PointController.java
+++ b/src/main/java/com/team/buddyya/point/controller/PointController.java
@@ -26,13 +26,13 @@ public class PointController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping
+    @GetMapping("/missions")
     public ResponseEntity<PointMissionResponse> getUserMissionInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
         PointMissionResponse response = pointService.getUserMissionInfo(userDetails.getStudentInfo());
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping
+    @PostMapping("/attendances")
     public ResponseEntity<PointMissionRewardResponse> rewardVisitPoint(@AuthenticationPrincipal CustomUserDetails userDetails){
         PointMissionRewardResponse response = pointService.checkAttendanceAndReward(userDetails.getStudentInfo());
         return ResponseEntity.ok(response);

--- a/src/main/java/com/team/buddyya/point/controller/PointController.java
+++ b/src/main/java/com/team/buddyya/point/controller/PointController.java
@@ -2,14 +2,11 @@ package com.team.buddyya.point.controller;
 
 import com.team.buddyya.auth.domain.CustomUserDetails;
 import com.team.buddyya.point.dto.PointListResponse;
-import com.team.buddyya.point.dto.PointMissionResponse;
-import com.team.buddyya.point.dto.PointMissionRewardResponse;
 import com.team.buddyya.point.service.PointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,18 +20,6 @@ public class PointController {
     @GetMapping
     public ResponseEntity<PointListResponse> getPoints(@AuthenticationPrincipal CustomUserDetails userDetails) {
         PointListResponse response = pointService.getPoints(userDetails.getStudentInfo());
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/missions")
-    public ResponseEntity<PointMissionResponse> getUserMissionInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
-        PointMissionResponse response = pointService.getUserMissionInfo(userDetails.getStudentInfo());
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/attendances")
-    public ResponseEntity<PointMissionRewardResponse> rewardVisitPoint(@AuthenticationPrincipal CustomUserDetails userDetails){
-        PointMissionRewardResponse response = pointService.checkAttendanceAndReward(userDetails.getStudentInfo());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 @Getter
 public enum PointType {
 
-    SIGNUP("signup", 100, PointChangeType.EARN),
+    SIGNUP("signup", 50, PointChangeType.EARN),
     UNIVERSITY_AUTH("university_auth", 1, PointChangeType.EARN),
     INVITATION_EVENT("invitation_event", 100, PointChangeType.EARN),
     CHAT_REQUEST("chat_request", -15, PointChangeType.DEDUCT),

--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -18,6 +18,7 @@ public enum PointType {
     NO_POINT_CHANGE("no_point_change", 0, PointChangeType.NONE),
     REJECTED_CHAT_REQUEST("rejected_chat_request", 15, PointChangeType.EARN),
     CHATROOM_NO_RESPONSE_REFUND("chatroom_no_response_refund", 35, PointChangeType.EARN),
+    MISSION_CERTIFICATION_REWARD("mission_certification_reward", 100, PointChangeType.MISSION),
     MISSION_VISIT_REWARD("mission_visit_reward", 10, PointChangeType.MISSION),
     EVENT_REWARD("event_reward", 10, PointChangeType.EARN);
 

--- a/src/main/java/com/team/buddyya/point/dto/PointMissionResponse.java
+++ b/src/main/java/com/team/buddyya/point/dto/PointMissionResponse.java
@@ -1,14 +1,16 @@
 package com.team.buddyya.point.dto;
 
 import com.team.buddyya.certification.domain.RegisteredPhone;
+import com.team.buddyya.student.domain.Student;
 
 public record PointMissionResponse(
+        boolean isCertificated,
         boolean todayAttended,
         int totalMissionPoint
 ) {
 
-    public static PointMissionResponse from(RegisteredPhone registeredPhone, int totalMissionPoint) {
-        return new PointMissionResponse(registeredPhone.isTodayAttended(), totalMissionPoint);
+    public static PointMissionResponse from(Student student, RegisteredPhone registeredPhone, int totalMissionPoint) {
+        return new PointMissionResponse(student.getIsCertificated(), registeredPhone.isTodayAttended(), totalMissionPoint);
     }
 }
 

--- a/src/main/java/com/team/buddyya/point/dto/PointMissionResponse.java
+++ b/src/main/java/com/team/buddyya/point/dto/PointMissionResponse.java
@@ -4,13 +4,13 @@ import com.team.buddyya.certification.domain.RegisteredPhone;
 import com.team.buddyya.student.domain.Student;
 
 public record PointMissionResponse(
-        boolean isCertificated,
+        boolean hasCertificated,
         boolean todayAttended,
         int totalMissionPoint
 ) {
 
-    public static PointMissionResponse from(Student student, RegisteredPhone registeredPhone, int totalMissionPoint) {
-        return new PointMissionResponse(student.getIsCertificated(), registeredPhone.isTodayAttended(), totalMissionPoint);
+    public static PointMissionResponse from(RegisteredPhone registeredPhone, int totalMissionPoint) {
+        return new PointMissionResponse(registeredPhone.getHasCertificated(), registeredPhone.isTodayAttended(), totalMissionPoint);
     }
 }
 

--- a/src/main/java/com/team/buddyya/point/service/PointService.java
+++ b/src/main/java/com/team/buddyya/point/service/PointService.java
@@ -5,15 +5,11 @@ import com.team.buddyya.certification.domain.RegisteredPhone;
 import com.team.buddyya.certification.exception.PhoneAuthenticationException;
 import com.team.buddyya.certification.exception.PhoneAuthenticationExceptionType;
 import com.team.buddyya.certification.repository.RegisteredPhoneRepository;
-import com.team.buddyya.notification.service.NotificationService;
 import com.team.buddyya.point.domain.Point;
-import com.team.buddyya.point.domain.PointChangeType;
 import com.team.buddyya.point.domain.PointStatus;
 import com.team.buddyya.point.domain.PointType;
 import com.team.buddyya.point.dto.PointListResponse;
-import com.team.buddyya.point.dto.PointMissionResponse;
 import com.team.buddyya.point.dto.PointResponse;
-import com.team.buddyya.point.dto.PointMissionRewardResponse;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.point.repository.PointRepository;
 import com.team.buddyya.point.repository.PointStatusRepository;
@@ -31,12 +27,10 @@ import java.util.stream.Collectors;
 public class PointService {
 
     private final PointRepository pointRepository;
-    private final UpdatePointService updatePointService;
     private final PointStatusRepository pointStatusRepository;
     private final FindPointService findPointService;
     private final FindStudentService findStudentService;
     private final RegisteredPhoneRepository registeredPhoneRepository;
-    private final NotificationService notificationService;
 
     public Point createPoint(Student student) {
         RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
@@ -72,33 +66,5 @@ public class PointService {
                 .map(PointResponse::from)
                 .collect(Collectors.toList());
         return PointListResponse.from(point, pointResponses);
-    }
-
-    public PointMissionResponse getUserMissionInfo(StudentInfo studentInfo){
-        Student student = findStudentService.findByStudentId(studentInfo.id());
-        RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
-                .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));
-        Point point = findPointService.findByStudent(student);
-        int totalMissionPoint = getTotalMissionPoint(point);
-        return PointMissionResponse.from(student, registeredPhone, totalMissionPoint);
-    }
-
-    public PointMissionRewardResponse checkAttendanceAndReward(StudentInfo studentInfo) {
-        Student student = findStudentService.findByStudentId(studentInfo.id());
-        RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
-                .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));
-        if (registeredPhone.isTodayAttended()) {
-            return PointMissionRewardResponse.from(null, PointType.NO_POINT_CHANGE.getPointChange());
-        }
-        Point point = updatePointService.updatePoint(student, PointType.MISSION_VISIT_REWARD);
-        registeredPhone.updateLastAttendanceDateToToday();
-        return PointMissionRewardResponse.from(point.getCurrentPoint(), PointType.MISSION_VISIT_REWARD.getPointChange());
-    }
-
-    public int getTotalMissionPoint(Point point) {
-        return pointStatusRepository.findAllByPointOrderByCreatedDateDesc(point).stream()
-                .filter(ps -> ps.getPointType().getChangeType() == PointChangeType.MISSION)
-                .mapToInt(PointStatus::getChangedPoint)
-                .sum();
     }
 }

--- a/src/main/java/com/team/buddyya/point/service/PointService.java
+++ b/src/main/java/com/team/buddyya/point/service/PointService.java
@@ -80,7 +80,7 @@ public class PointService {
                 .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));
         Point point = findPointService.findByStudent(student);
         int totalMissionPoint = getTotalMissionPoint(point);
-        return PointMissionResponse.from(registeredPhone, totalMissionPoint);
+        return PointMissionResponse.from(student, registeredPhone, totalMissionPoint);
     }
 
     public PointMissionRewardResponse checkAttendanceAndReward(StudentInfo studentInfo) {

--- a/src/main/resources/db/migration/V27__Add_registered_phone_number_has_certificated.sql
+++ b/src/main/resources/db/migration/V27__Add_registered_phone_number_has_certificated.sql
@@ -1,0 +1,13 @@
+ALTER TABLE registered_phone_number
+    ADD has_certificated BIT(1) NULL;
+
+UPDATE registered_phone_number rpn
+    JOIN student s ON rpn.phone_number = s.phone_number
+    SET rpn.has_certificated = s.certificated;
+
+UPDATE registered_phone_number
+SET has_certificated = false
+WHERE has_certificated IS NULL;
+
+ALTER TABLE registered_phone_number
+    MODIFY has_certificated BIT(1) NOT NULL;


### PR DESCRIPTION
## 📌 관련 이슈
[기존 회원가입 포인트 정책 개선 및 인증 미션 도입](https://github.com/buddy-ya/be/issues/327)[#327]

<br><br>

## 🛠️ 작업 내용
- 기존 회원 가입 포인트 100에서 50에 인하
- 인증시 100 포인트 지급
1. 이메일 인증
2. 학생증 인증
- 미션 페이지에 인증 여부 응답값에 추가

<br><br>

## 🎯 리뷰 포인트
- 포인트가 변동될 수도 있고 변동되지 않을 수도 있는 상황에서, 응답 DTO에는 변동 여부와 관계없이 항상 현재 포인트 정보를 포함해야 합니다. 현재는 인증 처리 이후 포인트를 조회하여 응답에 사용하고 있는데, 이보다 더 적절한 DTO 구조가 있다면 제안 부탁드립니다.

<br><br>

## 📎 커밋 범위 링크

<br><br>
