### PR TITLE
refactor: 회원가입 포인트 정책 변경에 따른 NEW_SIGNUP 분리

### DIFF
--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 @Getter
 public enum PointType {
 
-    NEW_SIGNUP("signup", 50, PointChangeType.EARN),
+    NEW_SIGNUP("new_signup", 50, PointChangeType.EARN),
     SIGNUP("signup", 100, PointChangeType.EARN),
     UNIVERSITY_AUTH("university_auth", 1, PointChangeType.EARN),
     INVITATION_EVENT("invitation_event", 100, PointChangeType.EARN),

--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -9,7 +9,8 @@ import java.util.Arrays;
 @Getter
 public enum PointType {
 
-    SIGNUP("signup", 50, PointChangeType.EARN),
+    NEW_SIGNUP("signup", 50, PointChangeType.EARN),
+    SIGNUP("signup", 100, PointChangeType.EARN),
     UNIVERSITY_AUTH("university_auth", 1, PointChangeType.EARN),
     INVITATION_EVENT("invitation_event", 100, PointChangeType.EARN),
     CHAT_REQUEST("chat_request", -15, PointChangeType.DEDUCT),

--- a/src/main/java/com/team/buddyya/point/service/PointService.java
+++ b/src/main/java/com/team/buddyya/point/service/PointService.java
@@ -36,7 +36,7 @@ public class PointService {
         RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
                 .orElseThrow(() -> new PhoneAuthenticationException(PhoneAuthenticationExceptionType.PHONE_NOT_FOUND));
         boolean hasWithdrawn = registeredPhone.getHasWithdrawn();
-        PointType pointType = hasWithdrawn ? PointType.NO_POINT_CHANGE : PointType.SIGNUP;
+        PointType pointType = hasWithdrawn ? PointType.NO_POINT_CHANGE : PointType.NEW_SIGNUP;
         Point point = createAndSavePoint(student, pointType, hasWithdrawn);
         return point;
     }


### PR DESCRIPTION
## 📌 관련 이슈
[회원가입 포인트 정책 변경에 따른 ENUM 분리](https://github.com/buddy-ya/be/issues/335)[#335]

<br><br>

## 🛠️ 작업 내용
기존 회원가입 포인트는 100이었으나, 최근 정책 변경으로 새로운 가입자에게 지급되는 포인트가 달라졌습니다.
하지만 기존 ENUM을 그대로 사용할 경우 과거 가입자에게도 잘못된 포인트가 계산되어 총 포인트가 잘못 표시되는 문제가 있었습니다.

이에 따라 과거 정책의 포인트 값을 유지하기 위해 기존 ENUM은 그대로 두고,
신규 정책을 반영한 새로운 회원가입 포인트 ENUM을 추가하였습니다.
총 포인트 계산 로직도 이에 맞게 수정하였습니다.

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
