### PR TITLE
feat: 페스티벌 기간동안 회원 가입 시에 추가적인 리워드 지급

### DIFF
--- a/src/main/java/com/team/buddyya/point/domain/PointType.java
+++ b/src/main/java/com/team/buddyya/point/domain/PointType.java
@@ -21,6 +21,7 @@ public enum PointType {
     CHATROOM_NO_RESPONSE_REFUND("chatroom_no_response_refund", 35, PointChangeType.EARN),
     MISSION_CERTIFICATION_REWARD("mission_certification_reward", 100, PointChangeType.MISSION),
     MISSION_VISIT_REWARD("mission_visit_reward", 10, PointChangeType.MISSION),
+    FESTIVAL_REWARD("festival_reward", 50, PointChangeType.EARN),
     EVENT_REWARD("event_reward", 10, PointChangeType.EARN);
 
     private final String displayName;

--- a/src/main/java/com/team/buddyya/point/service/PointService.java
+++ b/src/main/java/com/team/buddyya/point/service/PointService.java
@@ -31,6 +31,7 @@ public class PointService {
     private final FindPointService findPointService;
     private final FindStudentService findStudentService;
     private final RegisteredPhoneRepository registeredPhoneRepository;
+    private final UpdatePointService updatePointService;
 
     public Point createPoint(Student student) {
         RegisteredPhone registeredPhone = registeredPhoneRepository.findByPhoneNumber(student.getPhoneNumber())
@@ -38,6 +39,9 @@ public class PointService {
         boolean hasWithdrawn = registeredPhone.getHasWithdrawn();
         PointType pointType = hasWithdrawn ? PointType.NO_POINT_CHANGE : PointType.NEW_SIGNUP;
         Point point = createAndSavePoint(student, pointType, hasWithdrawn);
+        if (!hasWithdrawn) {
+            return rewardFestivalPoint(student);
+        }
         return point;
     }
 
@@ -66,5 +70,9 @@ public class PointService {
                 .map(PointResponse::from)
                 .collect(Collectors.toList());
         return PointListResponse.from(point, pointResponses);
+    }
+
+    private Point rewardFestivalPoint(Student student) {
+        return updatePointService.updatePoint(student, PointType.FESTIVAL_REWARD);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
[축제 기간 동안 회원 가입시 추가 포인트 지급](https://github.com/buddy-ya/be/issues/340)[#340]

<br><br>

## 🛠️ 작업 내용
- 회원 가입 시 FESTIVAL_REWARD 포인트를 추가로 지급하는 로직을 적용했습니다.
- 탈퇴 이력이 없는 회원에게만 지급되며, 페스티벌 종료 시 해당 로직은 주석 처리 또는 제거 예정입니다.

<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
