### PR TITLE
feat: 피드 인기, 고정게시글 기능 구현 

### DIFF
--- a/src/main/java/com/team/buddyya/feed/controller/FeedController.java
+++ b/src/main/java/com/team/buddyya/feed/controller/FeedController.java
@@ -38,7 +38,8 @@ public class FeedController {
 
     @GetMapping
     public ResponseEntity<FeedListResponse> getFeeds(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                     @PageableDefault(size = 10, sort = "createdDate", direction = Direction.DESC) Pageable pageable,
+                                                     @PageableDefault(size = 10, sort = {"pinned",
+                                                             "createdDate"}, direction = Direction.DESC) Pageable pageable,
                                                      @ModelAttribute FeedListRequest request) {
         FeedListResponse response = feedService.getFeeds(userDetails.getStudentInfo(), pageable, request);
         return ResponseEntity.ok(response);
@@ -96,5 +97,14 @@ public class FeedController {
                                                             @PageableDefault(size = 10, sort = "createdDate", direction = Direction.DESC) Pageable pageable) {
         FeedListResponse response = feedService.getPopularFeeds(userDetails.getStudentInfo(), pageable);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{feedId}/pin")
+    public ResponseEntity<Void> togglePin(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long feedId
+    ) {
+        feedService.togglePin(userDetails.getStudentInfo(), feedId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -50,6 +50,9 @@ public class Feed extends BaseTime {
     @Column(name = "is_profile_visible", nullable = false)
     private boolean isProfileVisible;
 
+    @Column(name = "pinned", nullable = false)
+    private boolean pinned;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
@@ -86,6 +89,7 @@ public class Feed extends BaseTime {
         this.likeCount = 0;
         this.commentCount = 0;
         this.viewCount = 0;
+        this.pinned = false;
     }
 
     public void updateFeed(String title, String content, Category category, boolean isProfileVisible) {
@@ -117,6 +121,10 @@ public class Feed extends BaseTime {
 
     public void uploadFeedImages(List<FeedImage> images) {
         this.images = images;
+    }
+
+    public void togglePin() {
+        this.pinned = !this.pinned;
     }
 
     public boolean isFeedOwner(Long studentId) {

--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
@@ -2,6 +2,7 @@ package com.team.buddyya.feed.dto.response.comment;
 
 import com.team.buddyya.feed.domain.Comment;
 import com.team.buddyya.feed.repository.CommentLikeRepository;
+import com.team.buddyya.student.domain.Role;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -26,8 +27,13 @@ public record CommentResponse(
         List<CommentResponse> replies
 ) {
 
+    private static final String BUDDYYA_PROFILE_IMAGE =
+            "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/buddyya_icon.png";
+
     public static CommentResponse from(Comment comment, Long feedOwnerId, Long currentUserId,
                                        CommentLikeRepository commentLikeRepository, Set<Long> blockedStudentIds) {
+        String profileImageUrl = comment.getStudent().getRole() == Role.OWNER ? BUDDYYA_PROFILE_IMAGE
+                : comment.getStudent().getCharacterProfileImage();
         boolean isFeedOwner = feedOwnerId.equals(comment.getStudent().getId());
         boolean isCommentOwner = currentUserId.equals(comment.getStudent().getId());
         boolean isLiked = commentLikeRepository.existsByCommentAndStudentId(comment, currentUserId);
@@ -43,7 +49,7 @@ public record CommentResponse(
                 comment.getStudent().getName(),
                 comment.getStudent().getCountry(),
                 comment.getStudent().getUniversity().getUniversityName(),
-                comment.getStudent().getCharacterProfileImage(),
+                profileImageUrl,
                 comment.getLikeCount(),
                 comment.getCreatedDate(),
                 comment.isDeleted(),

--- a/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/comment/CommentResponse.java
@@ -2,9 +2,6 @@ package com.team.buddyya.feed.dto.response.comment;
 
 import com.team.buddyya.feed.domain.Comment;
 import com.team.buddyya.feed.repository.CommentLikeRepository;
-import com.team.buddyya.student.domain.Student;
-import com.team.buddyya.student.domain.UserProfileDefaultImage;
-import com.team.buddyya.student.repository.BlockRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -24,7 +21,7 @@ public record CommentResponse(
         boolean isFeedOwner,
         boolean isCommentOwner,
         boolean isBlocked,
-        boolean isProfileImageUpload,
+        boolean isCertificated,
         boolean isStudentDeleted,
         List<CommentResponse> replies
 ) {
@@ -33,11 +30,11 @@ public record CommentResponse(
                                        CommentLikeRepository commentLikeRepository, Set<Long> blockedStudentIds) {
         boolean isFeedOwner = feedOwnerId.equals(comment.getStudent().getId());
         boolean isCommentOwner = currentUserId.equals(comment.getStudent().getId());
-        boolean isProfileImageUpload = UserProfileDefaultImage.isProfileImageUpload(comment.getStudent());
         boolean isLiked = commentLikeRepository.existsByCommentAndStudentId(comment, currentUserId);
         boolean isBlocked = blockedStudentIds.contains(comment.getStudent().getId());
         List<CommentResponse> replies = comment.getChildren().stream()
-                .map(reply -> CommentResponse.from(reply, feedOwnerId, currentUserId, commentLikeRepository, blockedStudentIds))
+                .map(reply -> CommentResponse.from(reply, feedOwnerId, currentUserId, commentLikeRepository,
+                        blockedStudentIds))
                 .toList();
         return new CommentResponse(
                 comment.getId(),
@@ -54,7 +51,7 @@ public record CommentResponse(
                 isFeedOwner,
                 isCommentOwner,
                 isBlocked,
-                isProfileImageUpload,
+                comment.getStudent().getIsCertificated(),
                 comment.getStudent().getIsDeleted(),
                 replies
         );

--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -3,6 +3,7 @@ package com.team.buddyya.feed.dto.response.feed;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.domain.FeedImage;
 import com.team.buddyya.feed.domain.FeedUserAction;
+import com.team.buddyya.student.domain.Role;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -30,7 +31,12 @@ public record FeedResponse(
         LocalDateTime createdDate
 ) {
 
+    private static final String BUDDYYA_PROFILE_IMAGE =
+            "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/buddyya_icon.png";
+
     public static FeedResponse from(Feed feed, FeedUserAction userAction) {
+        String profileImageUrl = feed.getStudent().getRole() == Role.OWNER ? BUDDYYA_PROFILE_IMAGE
+                : feed.getStudent().getCharacterProfileImage();
         return new FeedResponse(
                 feed.getId(),
                 feed.getStudent().getId(),
@@ -41,7 +47,7 @@ public record FeedResponse(
                 feed.getTitle(),
                 feed.getContent(),
                 feed.getStudent().getUniversity().getUniversityName(),
-                feed.getStudent().getCharacterProfileImage(),
+                profileImageUrl,
                 feed.getImages().stream()
                         .map(FeedImage::getUrl)
                         .toList(),

--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -3,7 +3,6 @@ package com.team.buddyya.feed.dto.response.feed;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.domain.FeedImage;
 import com.team.buddyya.feed.domain.FeedUserAction;
-import com.team.buddyya.student.domain.UserProfileDefaultImage;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,15 +24,13 @@ public record FeedResponse(
         boolean isFeedOwner,
         boolean isLiked,
         boolean isBookmarked,
-        boolean isProfileImageUpload,
+        boolean isCertificated,
         boolean isProfileVisible,
         boolean isStudentDeleted,
         LocalDateTime createdDate
 ) {
 
     public static FeedResponse from(Feed feed, FeedUserAction userAction) {
-        boolean isProfileImageUpload = UserProfileDefaultImage.isProfileImageUpload(feed.getStudent());
-
         return new FeedResponse(
                 feed.getId(),
                 feed.getStudent().getId(),
@@ -54,7 +51,7 @@ public record FeedResponse(
                 userAction.isFeedOwner(),
                 userAction.isLiked(),
                 userAction.isBookmarked(),
-                isProfileImageUpload,
+                feed.getStudent().getIsCertificated(),
                 feed.isProfileVisible(),
                 feed.getStudent().getIsDeleted(),
                 feed.getCreatedDate()

--- a/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
+++ b/src/main/java/com/team/buddyya/feed/exception/FeedExceptionType.java
@@ -15,7 +15,9 @@ public enum FeedExceptionType implements BaseExceptionType {
     COMMENT_NOT_FOUND(4006, HttpStatus.NOT_FOUND, "Comment not found."),
     NOT_COMMENT_OWNER(4007, HttpStatus.FORBIDDEN, "You are not the owner of this comment."),
     COMMENT_NOT_LIKED(4003, HttpStatus.NOT_FOUND, "This comment has not been liked."),
-    COMMENT_DEPTH_LIMIT(4008, HttpStatus.FORBIDDEN, "Nested replies beyond this depth are not allowed.");
+    COMMENT_DEPTH_LIMIT(4008, HttpStatus.FORBIDDEN, "Nested replies beyond this depth are not allowed."),
+    STUDENT_NOT_OWNER(4009, HttpStatus.BAD_REQUEST, "You cannot access owner function");
+
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -20,6 +20,7 @@ import com.team.buddyya.feed.repository.FeedLikeRepository;
 import com.team.buddyya.feed.repository.FeedRepository;
 import com.team.buddyya.report.domain.ReportType;
 import com.team.buddyya.report.repository.ReportRepository;
+import com.team.buddyya.student.domain.Role;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.domain.University;
 import com.team.buddyya.student.exception.StudentException;
@@ -185,6 +186,15 @@ public class FeedService {
             feedImageService.deleteS3FeedImages(feed);
         }
         feedRepository.delete(feed);
+    }
+
+    public void togglePin(StudentInfo studentInfo, Long feedId) {
+        Feed feed = findFeedByFeedId(feedId);
+        Student student = findStudentByStudentId(studentInfo.id());
+        if (student.getRole() != Role.OWNER) {
+            throw new FeedException(FeedExceptionType.STUDENT_NOT_OWNER);
+        }
+        feed.togglePin();
     }
 
     private List<FeedResponse> filterBlockedFeeds(List<Feed> feeds, Set<Long> blockedStudentIds,

--- a/src/main/java/com/team/buddyya/student/domain/Role.java
+++ b/src/main/java/com/team/buddyya/student/domain/Role.java
@@ -1,5 +1,5 @@
 package com.team.buddyya.student.domain;
 
 public enum Role {
-    ADMIN, STUDENT
+    OWNER, ADMIN, STUDENT
 }

--- a/src/main/java/com/team/buddyya/student/domain/University.java
+++ b/src/main/java/com/team/buddyya/student/domain/University.java
@@ -28,10 +28,10 @@ public class University {
     @Column(name = "active", nullable = false)
     private Boolean isActive;
 
-    @Column(name = "matchActive", nullable = false)
+    @Column(name = "match_active", nullable = false)
     private Boolean isMatchingActive;
 
-    @Column(name = "feedActive", nullable = false)
+    @Column(name = "feed_active", nullable = false)
     private Boolean isFeedActive;
 
     @Builder

--- a/src/main/java/com/team/buddyya/student/domain/University.java
+++ b/src/main/java/com/team/buddyya/student/domain/University.java
@@ -28,10 +28,10 @@ public class University {
     @Column(name = "active", nullable = false)
     private Boolean isActive;
 
-    @Column(name = "match", nullable = false)
+    @Column(name = "matchActive", nullable = false)
     private Boolean isMatchingActive;
 
-    @Column(name = "feed", nullable = false)
+    @Column(name = "feedActive", nullable = false)
     private Boolean isFeedActive;
 
     @Builder

--- a/src/main/java/com/team/buddyya/student/domain/University.java
+++ b/src/main/java/com/team/buddyya/student/domain/University.java
@@ -1,12 +1,16 @@
 package com.team.buddyya.student.domain;
 
-import jakarta.persistence.*;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Table(name = "university")
@@ -24,9 +28,17 @@ public class University {
     @Column(name = "active", nullable = false)
     private Boolean isActive;
 
+    @Column(name = "match", nullable = false)
+    private Boolean isMatchingActive;
+
+    @Column(name = "feed", nullable = false)
+    private Boolean isFeedActive;
+
     @Builder
     public University(String universityName) {
         this.universityName = universityName;
         isActive = true;
+        isMatchingActive = true;
+        isFeedActive = false;
     }
 }

--- a/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
@@ -1,15 +1,14 @@
 package com.team.buddyya.student.dto.response;
 
+import static com.team.buddyya.student.domain.UserProfileDefaultImage.getChatroomProfileImage;
+import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
+
 import com.team.buddyya.point.domain.Point;
 import com.team.buddyya.student.domain.MatchingProfile;
 import com.team.buddyya.student.domain.Student;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static com.team.buddyya.student.domain.UserProfileDefaultImage.getChatroomProfileImage;
-import static com.team.buddyya.student.domain.UserProfileDefaultImage.isDefaultUserProfileImage;
 
 public record UserResponse(
         Long id,
@@ -36,10 +35,13 @@ public record UserResponse(
         String refreshToken,
         String introduction,
         String buddyActivity,
-        Boolean isMatchingProfileCompleted
+        Boolean isMatchingProfileCompleted,
+        Boolean isMatchingActive,
+        Boolean isFeedActive
 ) {
 
-    public static UserResponse fromUserInfo(Student student, boolean isStudentIdCardRequested, Point point, Integer totalUnreadCount, MatchingProfile matchingProfile) {
+    public static UserResponse fromUserInfo(Student student, boolean isStudentIdCardRequested, Point point,
+                                            Integer totalUnreadCount, MatchingProfile matchingProfile) {
         return new UserResponse(
                 student.getId(),
                 student.getRole().name(),
@@ -65,7 +67,9 @@ public record UserResponse(
                 null,
                 matchingProfile.getIntroduction(),
                 matchingProfile.getBuddyActivity(),
-                matchingProfile.isCompleted()
+                matchingProfile.isCompleted(),
+                student.getUniversity().getIsMatchingActive(),
+                student.getUniversity().getIsFeedActive()
         );
     }
 
@@ -95,11 +99,14 @@ public record UserResponse(
                 null,
                 matchingProfile.getIntroduction(),
                 matchingProfile.getBuddyActivity(),
-                matchingProfile.isCompleted()
+                matchingProfile.isCompleted(),
+                null,
+                null
         );
     }
 
-    public static UserResponse fromOnboard(Student student, Boolean isStudentIdCardRequested, String accessToken, String refreshToken, Point point) {
+    public static UserResponse fromOnboard(Student student, Boolean isStudentIdCardRequested, String accessToken,
+                                           String refreshToken, Point point) {
         return new UserResponse(
                 student.getId(),
                 student.getRole().name(),
@@ -125,11 +132,14 @@ public record UserResponse(
                 refreshToken,
                 null,
                 null,
-                null
+                null,
+                student.getUniversity().getIsMatchingActive(),
+                student.getUniversity().getIsFeedActive()
         );
     }
 
-    public static UserResponse fromCheckMembership(Student student, Boolean isStudentIdCardRequested, String status, String accessToken, String refreshToken, Point point) {
+    public static UserResponse fromCheckMembership(Student student, Boolean isStudentIdCardRequested, String status,
+                                                   String accessToken, String refreshToken, Point point) {
         return new UserResponse(
                 student.getId(),
                 student.getRole().name(),
@@ -155,7 +165,9 @@ public record UserResponse(
                 refreshToken,
                 null,
                 null,
-                null
+                null,
+                student.getUniversity().getIsMatchingActive(),
+                student.getUniversity().getIsFeedActive()
         );
     }
 
@@ -177,6 +189,8 @@ public record UserResponse(
                 null,
                 status,
                 false,
+                null,
+                null,
                 null,
                 null,
                 null,

--- a/src/main/java/com/team/buddyya/student/exception/StudentExceptionType.java
+++ b/src/main/java/com/team/buddyya/student/exception/StudentExceptionType.java
@@ -15,7 +15,8 @@ public enum StudentExceptionType implements BaseExceptionType {
     INVALID_GENDER_VALUE(2000, HttpStatus.BAD_REQUEST, "Invalid gender value."),
     INVALID_DEFAULT_IMAGE_KEY(2000, HttpStatus.BAD_REQUEST, "Invalid profile image key."),
     INVALID_NAME_UPDATE_REQUEST(2001, HttpStatus.BAD_REQUEST, "Only one value is required for name update."),
-    INVALID_INTRODUCTION_UPDATE_REQUEST(2001, HttpStatus.BAD_REQUEST, "Only one value is required for introduction update."),
+    INVALID_INTRODUCTION_UPDATE_REQUEST(2001, HttpStatus.BAD_REQUEST,
+            "Only one value is required for introduction update."),
     INVALID_ACTIVITY_UPDATE_REQUEST(2001, HttpStatus.BAD_REQUEST, "Only one value is required for activity update."),
     UNSUPPORTED_UPDATE_KEY(2002, HttpStatus.BAD_REQUEST, "Unsupported update key."),
     INVALID_INTRODUCTION_LENGTH(2003, HttpStatus.BAD_REQUEST, "Introduction must be at least 10 characters long."),
@@ -24,7 +25,8 @@ public enum StudentExceptionType implements BaseExceptionType {
     ALREADY_BLOCKED(2011, HttpStatus.CONFLICT, "User is already blocked."),
     INVITATION_CODE_NOT_FOUND(2012, HttpStatus.NOT_FOUND, "Invitation code not found."),
     INVALID_INVITATION_CODE(2013, HttpStatus.BAD_REQUEST, "This Invitation code is not valid."),
-    INVITATION_EVENT_ALREADY_PARTICIPATED(2014, HttpStatus.BAD_REQUEST, "You have already joined the invitation event."),
+    INVITATION_EVENT_ALREADY_PARTICIPATED(2014, HttpStatus.BAD_REQUEST,
+            "You have already joined the invitation event."),
     SELF_INVITATION_CODE(2015, HttpStatus.BAD_REQUEST, "You cannot use your own invitation code.");
 
     private final int errorCode;

--- a/src/main/resources/db/migration/V28__Add_feed_pinned.sql
+++ b/src/main/resources/db/migration/V28__Add_feed_pinned.sql
@@ -1,0 +1,2 @@
+ALTER TABLE feed
+    ADD COLUMN pinned BIT(1) NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V29__Add_university_match_and_feed_active.sql
+++ b/src/main/resources/db/migration/V29__Add_university_match_and_feed_active.sql
@@ -1,0 +1,3 @@
+ALTER TABLE university
+    ADD COLUMN matchActive BIT(1) NOT NULL DEFAULT 1,
+    ADD COLUMN feedActive  BIT(1) NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V29__Add_university_match_and_feed_active.sql
+++ b/src/main/resources/db/migration/V29__Add_university_match_and_feed_active.sql
@@ -1,3 +1,3 @@
 ALTER TABLE university
-    ADD COLUMN match_active BIT(1) NOT NULL DEFAULT 1,
-    ADD COLUMN feed_active  BIT(1) NOT NULL DEFAULT 0;
+    ADD COLUMN matchActive BIT(1) NOT NULL DEFAULT 1,
+    ADD COLUMN feedActive  BIT(1) NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V29__Add_university_match_and_feed_active.sql
+++ b/src/main/resources/db/migration/V29__Add_university_match_and_feed_active.sql
@@ -1,3 +1,3 @@
 ALTER TABLE university
-    ADD COLUMN matchActive BIT(1) NOT NULL DEFAULT 1,
-    ADD COLUMN feedActive  BIT(1) NOT NULL DEFAULT 0;
+    ADD COLUMN match_active BIT(1) NOT NULL DEFAULT 1,
+    ADD COLUMN feed_active  BIT(1) NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V30__Update_university_column.sql
+++ b/src/main/resources/db/migration/V30__Update_university_column.sql
@@ -1,5 +1,0 @@
-ALTER TABLE university
-    DROP COLUMN matchActive,
-    DROP COLUMN feedActive,
-    ADD COLUMN match_active BIT(1) NOT NULL DEFAULT 1,
-    ADD COLUMN feed_active  BIT(1) NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V30__Update_university_column.sql
+++ b/src/main/resources/db/migration/V30__Update_university_column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE university
+    DROP COLUMN matchActive,
+    DROP COLUMN feedActive,
+    ADD COLUMN match_active BIT(1) NOT NULL DEFAULT 1,
+    ADD COLUMN feed_active  BIT(1) NOT NULL DEFAULT 0;

--- a/src/test/java/com/team/buddyya/student/controller/UserControllerTest.java
+++ b/src/test/java/com/team/buddyya/student/controller/UserControllerTest.java
@@ -1,5 +1,11 @@
 package com.team.buddyya.student.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team.buddyya.feed.service.FeedService;
 import com.team.buddyya.student.dto.request.OnBoardingRequest;
@@ -8,6 +14,7 @@ import com.team.buddyya.student.service.InvitationService;
 import com.team.buddyya.student.service.OnBoardingService;
 import com.team.buddyya.student.service.StudentService;
 import com.team.buddyya.student.service.UniversityService;
+import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -19,13 +26,6 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -80,7 +80,7 @@ class UserControllerTest {
                 List.of("humanities", "social_sciences"), List.of("ko", "en"), List.of("kpop", "movie"),
                 null, false, null, null,
                 100, null, "access-token", "refresh-token",
-                null, null, false
+                null, null, false, true, false
         );
 
         when(onBoardingService.onboard(any(OnBoardingRequest.class))).thenReturn(response);


### PR DESCRIPTION
## 📌 관련 이슈
[인기 카테고리 구현 및 수도권 대학 확장 #347](https://github.com/buddy-ya/be/issues/347)
<br><br>

## 🛠️ 작업 내용
- `university` 테이블에 `matchActive`(기본값: true), `feedActive`(기본값: false) 컬럼 추가
- 인기 게시판 조회 API 및 정렬 로직 구현
- 피드 고정글(`pinned`) 기능 구현 및 정렬 적용
- 피드·댓글 조회 시 `Role = OWNER` 일 경우 버디야 프로필 이미지 반환 로직 추가 (버디야 공식 공지용)
- 피드·댓글 응답에 인증 여부(`isCertificated`) 필드 포함
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
