### PR TITLE
fix: 'pinned' 서비스에서 정렬 막힌 현상 해결 (#347)

### DIFF
--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -242,6 +242,6 @@ public class FeedService {
     private Sort getSortBy(Category category) {
         return category.getName().equals("POPULAR")
                 ? Sort.by(Sort.Direction.DESC, "likeCount", "createdDate")
-                : Sort.by(Sort.Direction.DESC, "createdDate");
+                : Sort.by(Sort.Direction.DESC, "pinned", "createdDate");
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
[인기 카테고리 구현 및 수도권 확장 #347](https://github.com/buddy-ya/be/issues/347) 
<br><br>

## 🛠️ 작업 내용
컨트롤러가 아닌 서비스 레이어에서 피드 목록을 정렬하고 있는 것을 확인했고,
`createdDate`보다 `pinned`에 우선순위를 두어 정렬시켰습니다.
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
