### PR TITLE
feat: 유저 전체에게 알림이 가는 기능 구현

### DIFF
--- a/src/main/java/com/team/buddyya/notification/controller/NotificationController.java
+++ b/src/main/java/com/team/buddyya/notification/controller/NotificationController.java
@@ -25,7 +25,7 @@ public class NotificationController {
 
     @PostMapping("/send-to-all")
     public ResponseEntity<Void> sendNotificationToAllUser(@RequestBody PushToAllUsersRequest request) {
-        notificationService.sendNotificationToAllUser(request.feedId());
+        notificationService.sendNotificationToAllUser(request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/team/buddyya/notification/controller/NotificationController.java
+++ b/src/main/java/com/team/buddyya/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.team.buddyya.notification.controller;
 
 import com.team.buddyya.auth.domain.CustomUserDetails;
+import com.team.buddyya.notification.dto.request.PushToAllUsersRequest;
 import com.team.buddyya.notification.dto.request.SaveTokenRequest;
 import com.team.buddyya.notification.dto.response.SaveTokenResponse;
 import com.team.buddyya.notification.service.NotificationService;
@@ -20,5 +21,11 @@ public class NotificationController {
     public ResponseEntity<SaveTokenResponse> registerPushToken(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                @RequestBody SaveTokenRequest request) {
         return ResponseEntity.ok(notificationService.savePushToken(userDetails.getStudentInfo().id(), request.token()));
+    }
+
+    @PostMapping("/send-to-all")
+    public ResponseEntity<Void> sendNotificationToAllUser(@RequestBody PushToAllUsersRequest request) {
+        notificationService.sendNotificationToAllUser(request.feedId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/team/buddyya/notification/dto/request/PushToAllUsersRequest.java
+++ b/src/main/java/com/team/buddyya/notification/dto/request/PushToAllUsersRequest.java
@@ -1,4 +1,4 @@
 package com.team.buddyya.notification.dto.request;
 
-public record PushToAllUsersRequest(long feedId) {
+public record PushToAllUsersRequest(long feedId, String title, String body) {
 }

--- a/src/main/java/com/team/buddyya/notification/dto/request/PushToAllUsersRequest.java
+++ b/src/main/java/com/team/buddyya/notification/dto/request/PushToAllUsersRequest.java
@@ -1,0 +1,4 @@
+package com.team.buddyya.notification.dto.request;
+
+public record PushToAllUsersRequest(long feedId) {
+}

--- a/src/main/java/com/team/buddyya/notification/service/NotificationService.java
+++ b/src/main/java/com/team/buddyya/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import com.team.buddyya.feed.repository.FeedRepository;
 import com.team.buddyya.match.domain.MatchRequest;
 import com.team.buddyya.notification.domain.ExpoToken;
 import com.team.buddyya.notification.domain.RequestNotification;
+import com.team.buddyya.notification.dto.request.PushToAllUsersRequest;
 import com.team.buddyya.notification.dto.response.SaveTokenResponse;
 import com.team.buddyya.notification.exception.NotificationException;
 import com.team.buddyya.notification.exception.NotificationExceptionType;
@@ -50,8 +51,6 @@ public class NotificationService {
     private final ObjectMapper objectMapper;
 
     private static final String TOKEN_SAVE_SUCCESS_MESSAGE = "토큰이 성공적으로 저장되었습니다.";
-
-    private static final String BROADCAST_TITLE_EN = "Important notification from Buddyya";
 
     private static final String FEED_REPLY_TITLE_KR = "새로운 대댓글이 달렸어요!";
     private static final String FEED_REPLY_TITLE_EN = "A new reply has been added!";
@@ -223,10 +222,11 @@ public class NotificationService {
         return isKorean ? FEED_REPLY_TITLE_KR : FEED_REPLY_TITLE_EN;
     }
 
-    public void sendNotificationToAllUser(long feedId) {
-        Feed feed = feedRepository.findById(feedId)
+    public void sendNotificationToAllUser(PushToAllUsersRequest request) {
+        Feed feed = feedRepository.findById(request.feedId())
                 .orElseThrow(() -> new FeedException(FeedExceptionType.FEED_NOT_FOUND));
-        String body = feed.getTitle();
+        String title = request.title();
+        String body = request.body();
         Map<String, Object> data = Map.of(
                 "feedId", feed.getId(),
                 "type", "FEED"
@@ -238,7 +238,7 @@ public class NotificationService {
                 if (token == null || token.isBlank()) continue;
                 RequestNotification notification = RequestNotification.builder()
                         .to(token)
-                        .title(BROADCAST_TITLE_EN)
+                        .title(title)
                         .body(body)
                         .data(data)
                         .build();


### PR DESCRIPTION
## 📌 관련 이슈
[유저 전체에게 알림이 가는 기능 구현](https://github.com/buddy-ya/be/issues/358)[#358]

<br><br>

## 🛠️ 작업 내용
- 포스트맨으로 유저 전체에게 중요 알림을 보내는 API 구현
- 알림 내용
```
{
  "to": "ExponentPushToken[xxxxxxx]",
  "title": "Important notification from Buddyya",
  "body": "이번 주말 행사 안내 📢",
  "data": {
    "feedId": 42,
    "type": "FEED"
  }
}
```


<br><br>

## 🎯 리뷰 포인트
- 해당 기능이 ADMIN 유저의 여부를 확인할 필요가 있을까요?

<br><br>

## 📎 커밋 범위 링크

<br><br>
