### PR TITLE
fix: 로그인시 기존 유저일 경우 매칭 프로필 전달

### DIFF
--- a/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
+++ b/src/main/java/com/team/buddyya/student/dto/response/UserResponse.java
@@ -139,7 +139,8 @@ public record UserResponse(
     }
 
     public static UserResponse fromCheckMembership(Student student, Boolean isStudentIdCardRequested, String status,
-                                                   String accessToken, String refreshToken, Point point) {
+                                                   String accessToken, String refreshToken, Point point,
+                                                   MatchingProfile matchingProfile) {
         return new UserResponse(
                 student.getId(),
                 student.getRole().name(),
@@ -163,9 +164,9 @@ public record UserResponse(
                 null,
                 accessToken,
                 refreshToken,
-                null,
-                null,
-                null,
+                matchingProfile.getIntroduction(),
+                matchingProfile.getBuddyActivity(),
+                matchingProfile.isCompleted(),
                 student.getUniversity().getIsMatchingActive(),
                 student.getUniversity().getIsFeedActive()
         );


### PR DESCRIPTION
## 📌 관련 이슈
[로그인시 매칭 프로필 전달 안되는 이슈 #362](https://github.com/buddy-ya/be/issues/362)
<br><br>

## 🛠️ 작업 내용
- `UserResponse` `checkMemberShip`에서 기존회원일 경우 매칭프로필을 포함해서 반환
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
