### PR TITLE
refactor: 피드 조회 성능 개선 및 N + 1 문제 해결 

### DIFF
--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -21,6 +21,7 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "feed")
@@ -68,6 +69,7 @@ public class Feed extends BaseTime {
     @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<FeedImage> images = new ArrayList<>();
 

--- a/src/main/java/com/team/buddyya/feed/domain/Feed.java
+++ b/src/main/java/com/team/buddyya/feed/domain/Feed.java
@@ -54,6 +54,7 @@ public class Feed extends BaseTime {
     @Column(name = "pinned", nullable = false)
     private boolean pinned;
 
+    @BatchSize(size = 100)
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;

--- a/src/main/java/com/team/buddyya/feed/dto/projection/FeedAuthorInfo.java
+++ b/src/main/java/com/team/buddyya/feed/dto/projection/FeedAuthorInfo.java
@@ -1,0 +1,15 @@
+package com.team.buddyya.feed.dto.projection;
+
+import com.team.buddyya.student.domain.Role;
+
+public record FeedAuthorInfo(
+        Long id,
+        String name,
+        String country,
+        Role role,
+        String characterProfileImage,
+        boolean isCertificated,
+        boolean isDeleted,
+        String universityName
+) {
+}

--- a/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/team/buddyya/feed/dto/response/feed/FeedResponse.java
@@ -3,6 +3,7 @@ package com.team.buddyya.feed.dto.response.feed;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.domain.FeedImage;
 import com.team.buddyya.feed.domain.FeedUserAction;
+import com.team.buddyya.feed.dto.projection.FeedAuthorInfo;
 import com.team.buddyya.student.domain.Role;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,19 +36,19 @@ public record FeedResponse(
     private static final String BUDDYYA_PROFILE_IMAGE =
             "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/buddyya_icon.png";
 
-    public static FeedResponse from(Feed feed, FeedUserAction userAction) {
-        String profileImageUrl = feed.getStudent().getRole() == Role.OWNER ? BUDDYYA_PROFILE_IMAGE
-                : feed.getStudent().getCharacterProfileImage();
+    public static FeedResponse from(Feed feed, FeedUserAction userAction, FeedAuthorInfo authorInfo) {
+        String profileImageUrl = authorInfo.role() == Role.OWNER ? BUDDYYA_PROFILE_IMAGE
+                : authorInfo.characterProfileImage();
         return new FeedResponse(
                 feed.getId(),
-                feed.getStudent().getId(),
+                authorInfo.id(),
                 feed.getUniversity().getUniversityName(),
                 feed.getCategory().getName(),
-                feed.getStudent().getName(),
-                feed.getStudent().getCountry(),
+                authorInfo.name(),
+                authorInfo.country(),
                 feed.getTitle(),
                 feed.getContent(),
-                feed.getStudent().getUniversity().getUniversityName(),
+                authorInfo.universityName(),
                 profileImageUrl,
                 feed.getImages().stream()
                         .map(FeedImage::getUrl)
@@ -59,9 +60,9 @@ public record FeedResponse(
                 userAction.isLiked(),
                 userAction.isBookmarked(),
                 feed.isPinned(),
-                feed.getStudent().getIsCertificated(),
+                authorInfo.isCertificated(),
                 feed.isProfileVisible(),
-                feed.getStudent().getIsDeleted(),
+                authorInfo.isDeleted(),
                 feed.getCreatedDate()
         );
     }

--- a/src/main/java/com/team/buddyya/feed/repository/BookmarkRepository.java
+++ b/src/main/java/com/team/buddyya/feed/repository/BookmarkRepository.java
@@ -3,10 +3,14 @@ package com.team.buddyya.feed.repository;
 import com.team.buddyya.feed.domain.Bookmark;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.student.domain.Student;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,4 +21,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     boolean existsByStudentAndFeed(Student student, Feed feed);
 
     Page<Bookmark> findAllByStudent(Student student, Pageable pageable);
+
+    @Query("SELECT b.feed.id FROM Bookmark b WHERE b.student.id = :studentId AND b.feed.id IN :feedIds")
+    Set<Long> findFeedIdsByStudentIdAndFeedIdsIn(@Param("studentId") Long studentId,
+                                                 @Param("feedIds") List<Long> feedIds);
 }

--- a/src/main/java/com/team/buddyya/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/team/buddyya/feed/repository/FeedLikeRepository.java
@@ -3,8 +3,12 @@ package com.team.buddyya.feed.repository;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.domain.FeedLike;
 import com.team.buddyya.student.domain.Student;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +17,8 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     Optional<FeedLike> findByStudentAndFeed(Student student, Feed feed);
 
     boolean existsByStudentAndFeed(Student student, Feed feed);
+
+    @Query("SELECT fl.feed.id FROM FeedLike fl WHERE fl.student.id = :studentId AND fl.feed.id IN :feedIds")
+    Set<Long> findFeedIdsByStudentIdAndFeedIdsIn(@Param("studentId") Long studentId,
+                                                 @Param("feedIds") List<Long> feedIds);
 }

--- a/src/main/java/com/team/buddyya/feed/repository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/repository/FeedRepository.java
@@ -23,6 +23,10 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     })
     Optional<Feed> findById(Long id);
 
+    @EntityGraph(attributePaths = {
+            "category",
+            "university",
+    })
     Page<Feed> findAllByUniversityAndCategory(University university, Category category, Pageable pageable);
 
     Page<Feed> findAllByStudent(Student student, Pageable pageable);

--- a/src/main/java/com/team/buddyya/feed/repository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/repository/FeedRepository.java
@@ -5,13 +5,23 @@ import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.domain.University;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = {
+            "category",
+            "university",
+            "images"
+    })
+    Optional<Feed> findById(Long id);
 
     Page<Feed> findAllByUniversityAndCategory(University university, Category category, Pageable pageable);
 

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -29,6 +29,7 @@ import com.team.buddyya.student.service.FindStudentService;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -37,6 +38,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -155,9 +157,20 @@ public class FeedService {
     }
 
     public FeedResponse getFeed(StudentInfo studentInfo, Long feedId) {
+        log.info("========== [DEBUG] START: getFeed (Feed ID: {}) ==========", feedId);
+
+        log.info("--- [DEBUG] 1. findFeedByFeedId 호출 ---");
         Feed feed = findFeedByFeedId(feedId);
-        feed.increaseViewCount();
-        return createFeedResponse(feed, studentInfo.id());
+        log.info("--- [DEBUG] 1. findFeedByFeedId 완료 ---");
+
+        feed.increaseViewCount(); // Dirty Checking으로 인해 트랜잭션 커밋 시 UPDATE 쿼리 발생
+
+        log.info("--- [DEBUG] 2. createFeedResponse 호출 시작 (추가 쿼리 발생 구간) ---");
+        FeedResponse response = createFeedResponse(feed, studentInfo.id());
+        log.info("--- [DEBUG] 2. createFeedResponse 호출 완료 ---");
+
+        log.info("========== [DEBUG] END: getFeed (Feed ID: {}) ==========", feedId);
+        return response;
     }
 
     public void createFeed(StudentInfo studentInfo, FeedCreateRequest request) {

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -6,6 +6,7 @@ import com.team.buddyya.feed.domain.Category;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.feed.domain.FeedImage;
 import com.team.buddyya.feed.domain.FeedUserAction;
+import com.team.buddyya.feed.dto.projection.FeedAuthorInfo;
 import com.team.buddyya.feed.dto.request.feed.FeedCreateRequest;
 import com.team.buddyya.feed.dto.request.feed.FeedListRequest;
 import com.team.buddyya.feed.dto.request.feed.FeedUpdateRequest;
@@ -24,10 +25,14 @@ import com.team.buddyya.student.domain.University;
 import com.team.buddyya.student.exception.StudentException;
 import com.team.buddyya.student.exception.StudentExceptionType;
 import com.team.buddyya.student.repository.BlockRepository;
+import com.team.buddyya.student.repository.StudentRepository;
 import com.team.buddyya.student.repository.UniversityRepository;
 import com.team.buddyya.student.service.FindStudentService;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -55,6 +60,7 @@ public class FeedService {
     private final BlockRepository blockRepository;
     private final UniversityRepository universityRepository;
     private final ReportRepository reportRepository;
+    private final StudentRepository studentRepository;
 
     @Transactional(readOnly = true)
     protected Feed findFeedByFeedId(Long feedId) {
@@ -79,14 +85,16 @@ public class FeedService {
         Page<Feed> feeds = (request.keyword() == null || request.keyword().isBlank())
                 ? getFeedsByUniversityAndCategory(request, pageable)
                 : getFeedsByKeyword(student, request.keyword(), pageable);
+
         Set<Long> blockedStudentIds = blockRepository.findBlockedStudentIdByBlockerId(studentInfo.id());
         List<Long> feedIds = feeds.getContent().stream()
                 .map(Feed::getId)
                 .toList();
         Set<Long> likedFeedIds = feedLikeRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
         Set<Long> bookmarkedFeedIds = bookmarkRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
+        Map<Long, FeedAuthorInfo> authorInfoMap = getFeedAuthorInfoMap(feeds.getContent());
         List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blockedStudentIds, student, likedFeedIds,
-                bookmarkedFeedIds);
+                bookmarkedFeedIds, authorInfoMap);
         return FeedListResponse.from(response, feeds);
     }
 
@@ -100,14 +108,15 @@ public class FeedService {
         University university = findUniversityByUniversityName(request.university());
         Page<Feed> feeds = feedRepository.findByLikeCountGreaterThanEqualAndUniversity(LIKE_COUNT_THRESHOLD, university,
                 pageable);
-        Set<Long> blocked = blockRepository.findBlockedStudentIdByBlockerId(studentInfo.id());
+        Set<Long> blockedStudentIds = blockRepository.findBlockedStudentIdByBlockerId(studentInfo.id());
         List<Long> feedIds = feeds.getContent().stream()
                 .map(Feed::getId)
                 .toList();
         Set<Long> likedFeedIds = feedLikeRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
         Set<Long> bookmarkedFeedIds = bookmarkRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
-        List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blocked, student, likedFeedIds,
-                bookmarkedFeedIds);
+        Map<Long, FeedAuthorInfo> authorInfoMap = getFeedAuthorInfoMap(feeds.getContent());
+        List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blockedStudentIds, student, likedFeedIds,
+                bookmarkedFeedIds, authorInfoMap);
         return FeedListResponse.from(response, feeds);
     }
 
@@ -150,9 +159,9 @@ public class FeedService {
 
         Set<Long> likedFeedIds = feedLikeRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
         Set<Long> bookmarkedFeedIds = bookmarkRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
-
+        Map<Long, FeedAuthorInfo> authorInfoMap = getFeedAuthorInfoMap(feeds.getContent());
         List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blockedStudentIds, student, likedFeedIds,
-                bookmarkedFeedIds);
+                bookmarkedFeedIds, authorInfoMap);
         return FeedListResponse.from(response, feeds);
     }
 
@@ -225,7 +234,8 @@ public class FeedService {
 
     private List<FeedResponse> filterBlockedFeeds(List<Feed> feeds, Set<Long> blockedStudentIds,
                                                   Student currentStudent, Set<Long> likedFeedIds,
-                                                  Set<Long> bookmarkedFeedIds) {
+                                                  Set<Long> bookmarkedFeedIds,
+                                                  Map<Long, FeedAuthorInfo> authorInfoMap) {
         return feeds.stream()
                 .filter(feed -> !blockedStudentIds.contains(feed.getStudent().getId()))
                 .map(feed -> {
@@ -233,9 +243,21 @@ public class FeedService {
                     boolean isLiked = likedFeedIds.contains(feed.getId());
                     boolean isBookmarked = bookmarkedFeedIds.contains(feed.getId());
                     FeedUserAction userAction = FeedUserAction.from(isFeedOwner, isLiked, isBookmarked);
-                    return FeedResponse.from(feed, userAction);
+                    FeedAuthorInfo authorInfo = authorInfoMap.get(feed.getStudent().getId());
+                    return FeedResponse.from(feed, userAction, authorInfo);
                 })
                 .toList();
+    }
+
+    private Map<Long, FeedAuthorInfo> getFeedAuthorInfoMap(List<Feed> feeds) {
+        Set<Long> studentIds = feeds.stream()
+                .map(feed -> feed.getStudent().getId())
+                .collect(Collectors.toSet());
+        if (studentIds.isEmpty()) {
+            return Map.of();
+        }
+        return studentRepository.findAuthorInfoByIdsIn(studentIds).stream()
+                .collect(Collectors.toMap(FeedAuthorInfo::id, Function.identity()));
     }
 
 
@@ -247,7 +269,18 @@ public class FeedService {
 
     private FeedResponse createFeedResponse(Feed feed, Student currentStudent) {
         FeedUserAction userAction = getUserAction(currentStudent, feed);
-        return FeedResponse.from(feed, userAction);
+        Student authorStudent = feed.getStudent();
+        FeedAuthorInfo authorInfo = new FeedAuthorInfo(
+                authorStudent.getId(),
+                authorStudent.getName(),
+                authorStudent.getCountry(),
+                authorStudent.getRole(),
+                authorStudent.getCharacterProfileImage(),
+                authorStudent.getIsCertificated(),
+                authorStudent.getIsDeleted(),
+                authorStudent.getUniversity().getUniversityName()
+        );
+        return FeedResponse.from(feed, userAction, authorInfo);
     }
 
     private void updateImages(Feed feed, List<MultipartFile> images) {

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -75,13 +75,18 @@ public class FeedService {
 
     @Transactional(readOnly = true)
     public FeedListResponse getFeeds(StudentInfo studentInfo, Pageable pageable, FeedListRequest request) {
-        String keyword = request.keyword();
         Student student = findStudentByStudentId(studentInfo.id());
-        Page<Feed> feeds = (keyword == null || keyword.isBlank())
+        Page<Feed> feeds = (request.keyword() == null || request.keyword().isBlank())
                 ? getFeedsByUniversityAndCategory(request, pageable)
-                : getFeedsByKeyword(student, keyword, pageable);
+                : getFeedsByKeyword(student, request.keyword(), pageable);
         Set<Long> blockedStudentIds = blockRepository.findBlockedStudentIdByBlockerId(studentInfo.id());
-        List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blockedStudentIds, studentInfo.id());
+        List<Long> feedIds = feeds.getContent().stream()
+                .map(Feed::getId)
+                .toList();
+        Set<Long> likedFeedIds = feedLikeRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
+        Set<Long> bookmarkedFeedIds = bookmarkRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
+        List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blockedStudentIds, student, likedFeedIds,
+                bookmarkedFeedIds);
         return FeedListResponse.from(response, feeds);
     }
 
@@ -91,15 +96,18 @@ public class FeedService {
             Pageable pageable,
             FeedListRequest request
     ) {
+        Student student = findStudentByStudentId(studentInfo.id());
         University university = findUniversityByUniversityName(request.university());
-        Page<Feed> feeds = feedRepository
-                .findByLikeCountGreaterThanEqualAndUniversity(
-                        LIKE_COUNT_THRESHOLD,
-                        university,
-                        pageable
-                );
+        Page<Feed> feeds = feedRepository.findByLikeCountGreaterThanEqualAndUniversity(LIKE_COUNT_THRESHOLD, university,
+                pageable);
         Set<Long> blocked = blockRepository.findBlockedStudentIdByBlockerId(studentInfo.id());
-        List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blocked, studentInfo.id());
+        List<Long> feedIds = feeds.getContent().stream()
+                .map(Feed::getId)
+                .toList();
+        Set<Long> likedFeedIds = feedLikeRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
+        Set<Long> bookmarkedFeedIds = bookmarkRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
+        List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blocked, student, likedFeedIds,
+                bookmarkedFeedIds);
         return FeedListResponse.from(response, feeds);
     }
 
@@ -125,7 +133,7 @@ public class FeedService {
         Student student = findStudentByStudentId(studentInfo.id());
         Page<Feed> feeds = feedRepository.findAllByStudent(student, customPageable);
         List<FeedResponse> response = feeds.getContent().stream()
-                .map(feed -> createFeedResponse(feed, studentInfo.id()))
+                .map(feed -> createFeedResponse(feed, student))
                 .toList();
         return FeedListResponse.from(response, feeds);
     }
@@ -136,7 +144,15 @@ public class FeedService {
         Page<Bookmark> bookmarks = bookmarkRepository.findAllByStudent(student, pageable);
         Page<Feed> feeds = bookmarks.map(Bookmark::getFeed);
         Set<Long> blockedStudentIds = blockRepository.findBlockedStudentIdByBlockerId(studentInfo.id());
-        List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blockedStudentIds, studentInfo.id());
+        List<Long> feedIds = feeds.getContent().stream()
+                .map(Feed::getId)
+                .toList();
+
+        Set<Long> likedFeedIds = feedLikeRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
+        Set<Long> bookmarkedFeedIds = bookmarkRepository.findFeedIdsByStudentIdAndFeedIdsIn(studentInfo.id(), feedIds);
+
+        List<FeedResponse> response = filterBlockedFeeds(feeds.getContent(), blockedStudentIds, student, likedFeedIds,
+                bookmarkedFeedIds);
         return FeedListResponse.from(response, feeds);
     }
 
@@ -157,19 +173,10 @@ public class FeedService {
     }
 
     public FeedResponse getFeed(StudentInfo studentInfo, Long feedId) {
-        log.info("========== [DEBUG] START: getFeed (Feed ID: {}) ==========", feedId);
-
-        log.info("--- [DEBUG] 1. findFeedByFeedId 호출 ---");
+        Student student = findStudentByStudentId(studentInfo.id());
         Feed feed = findFeedByFeedId(feedId);
-        log.info("--- [DEBUG] 1. findFeedByFeedId 완료 ---");
-
-        feed.increaseViewCount(); // Dirty Checking으로 인해 트랜잭션 커밋 시 UPDATE 쿼리 발생
-
-        log.info("--- [DEBUG] 2. createFeedResponse 호출 시작 (추가 쿼리 발생 구간) ---");
-        FeedResponse response = createFeedResponse(feed, studentInfo.id());
-        log.info("--- [DEBUG] 2. createFeedResponse 호출 완료 ---");
-
-        log.info("========== [DEBUG] END: getFeed (Feed ID: {}) ==========", feedId);
+        feed.increaseViewCount();
+        FeedResponse response = createFeedResponse(feed, student);
         return response;
     }
 
@@ -217,12 +224,20 @@ public class FeedService {
     }
 
     private List<FeedResponse> filterBlockedFeeds(List<Feed> feeds, Set<Long> blockedStudentIds,
-                                                  Long currentStudentId) {
+                                                  Student currentStudent, Set<Long> likedFeedIds,
+                                                  Set<Long> bookmarkedFeedIds) {
         return feeds.stream()
                 .filter(feed -> !blockedStudentIds.contains(feed.getStudent().getId()))
-                .map(feed -> createFeedResponse(feed, currentStudentId))
+                .map(feed -> {
+                    boolean isFeedOwner = feed.isFeedOwner(currentStudent.getId());
+                    boolean isLiked = likedFeedIds.contains(feed.getId());
+                    boolean isBookmarked = bookmarkedFeedIds.contains(feed.getId());
+                    FeedUserAction userAction = FeedUserAction.from(isFeedOwner, isLiked, isBookmarked);
+                    return FeedResponse.from(feed, userAction);
+                })
                 .toList();
     }
+
 
     private void validateFeedOwner(StudentInfo studentInfo, Feed feed) {
         if (!studentInfo.id().equals(feed.getStudent().getId()) && !(studentInfo.role() == Role.OWNER)) {
@@ -230,9 +245,8 @@ public class FeedService {
         }
     }
 
-    private FeedResponse createFeedResponse(Feed feed, Long studentId) {
-        Student student = findStudentByStudentId(studentId);
-        FeedUserAction userAction = getUserAction(student, feed);
+    private FeedResponse createFeedResponse(Feed feed, Student currentStudent) {
+        FeedUserAction userAction = getUserAction(currentStudent, feed);
         return FeedResponse.from(feed, userAction);
     }
 

--- a/src/main/java/com/team/buddyya/job/feed/FeedItemReader.java
+++ b/src/main/java/com/team/buddyya/job/feed/FeedItemReader.java
@@ -13,8 +13,6 @@ public class FeedItemReader implements ItemReader<FeedJobDTO> {
 
     private Long minStudentId;
     private Long maxStudentId;
-    private Long minUniversityId;
-    private Long maxUniversityId;
 
     public FeedItemReader(JdbcTemplate jdbcTemplate, int totalCount) {
         this.jdbcTemplate = jdbcTemplate;
@@ -24,17 +22,11 @@ public class FeedItemReader implements ItemReader<FeedJobDTO> {
     @Override
     public FeedJobDTO read() throws Exception {
         if (minStudentId == null) {
-            // Student, University 테이블의 데이터 존재 여부 및 ID 범위 초기화
             if (jdbcTemplate.queryForObject("SELECT COUNT(1) FROM student", Long.class) == 0) {
                 throw new IllegalStateException("Prerequisite data (Student) is missing.");
             }
             this.minStudentId = jdbcTemplate.queryForObject("SELECT MIN(id) FROM student", Long.class);
             this.maxStudentId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM student", Long.class);
-            if (jdbcTemplate.queryForObject("SELECT COUNT(1) FROM university", Long.class) == 0) {
-                throw new IllegalStateException("Prerequisite data (University) is missing.");
-            }
-            this.minUniversityId = jdbcTemplate.queryForObject("SELECT MIN(id) FROM university", Long.class);
-            this.maxUniversityId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM university", Long.class);
         }
 
         if (counter.get() >= totalCount) {
@@ -43,18 +35,16 @@ public class FeedItemReader implements ItemReader<FeedJobDTO> {
 
         int currentCount = counter.incrementAndGet();
         long randomStudentId = ThreadLocalRandom.current().nextLong(minStudentId, maxStudentId + 1);
-        long randomUniversityId = ThreadLocalRandom.current().nextLong(minUniversityId, maxUniversityId + 1);
-        // Category는 데이터가 적다고 가정하고 SQL로 랜덤 조회, 많아진다면 동일하게 MIN/MAX 방식으로 변경
-        Long randomCategoryId = jdbcTemplate.queryForObject("SELECT id FROM category ORDER BY RAND() LIMIT 1",
-                Long.class);
+        long universityId = 21L;
+        Long categoryId = 1L;
 
         return FeedJobDTO.builder()
-                .title("피드 제목 " + currentCount)
-                .content("피드 내용입니다. " + currentCount)
+                .title("Feed")
+                .content("" + currentCount)
                 .profileVisible(ThreadLocalRandom.current().nextBoolean())
                 .studentId(randomStudentId)
-                .categoryId(randomCategoryId)
-                .universityId(randomUniversityId)
+                .categoryId(categoryId)
+                .universityId(universityId)
                 .build();
     }
 }

--- a/src/main/java/com/team/buddyya/job/student/StudentItemReader.java
+++ b/src/main/java/com/team/buddyya/job/student/StudentItemReader.java
@@ -38,6 +38,7 @@ public class StudentItemReader implements ItemReader<StudentJobDTO> {
         String profileImageUrl = String.format(
                 "https://buddyya.s3.ap-northeast-2.amazonaws.com/default-profile-image/image__%d.png",
                 profileImageIndex);
+
         return StudentJobDTO.builder()
                 .phoneNumber("010" + String.format("%08d", index))
                 .name("student" + index)
@@ -48,7 +49,7 @@ public class StudentItemReader implements ItemReader<StudentJobDTO> {
                 .universityId(randomUniversityId)
                 .role("STUDENT")
                 .gender(gender)
-                .characterProfileImage("default_image_url_" + (index % 8))
+                .characterProfileImage(profileImageUrl)
                 .isBanned(false)
                 .build();
     }

--- a/src/main/java/com/team/buddyya/student/repository/StudentRepository.java
+++ b/src/main/java/com/team/buddyya/student/repository/StudentRepository.java
@@ -1,13 +1,23 @@
 package com.team.buddyya.student.repository;
 
+import com.team.buddyya.feed.dto.projection.FeedAuthorInfo;
 import com.team.buddyya.student.domain.Student;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
 
     Optional<Student> findByPhoneNumber(String phoneNumber);
 
     Optional<Object> findByEmail(String email);
+
+    @Query("SELECT new com.team.buddyya.feed.dto.projection.FeedAuthorInfo(" +
+            "s.id, s.name, s.country, s.role, s.characterProfileImage, s.isCertificated, s.isDeleted, u.universityName) "
+            +
+            "FROM Student s JOIN s.university u WHERE s.id IN :studentIds")
+    List<FeedAuthorInfo> findAuthorInfoByIdsIn(@Param("studentIds") Set<Long> studentIds);
 }


### PR DESCRIPTION
## 📌 관련 이슈
[피드 조회 API 성능 개선 및 쿼리 최적화 #367](https://github.com/buddy-ya/be/issues/367)

## 1. 개요
피드 목록 조회 API (`GET /feeds`)에서 발생하는 N+1 쿼리 문제를 해결하여 응답 성능을 개선했습니다.

현재 페이지 크기 (N=10) 기준으로 N+1 문제로 인해 **50회**의 추가 쿼리가 발생했습니다.
본 리팩토링을 통해 DTO 프로젝션, Batch Size 적용, Bulk 조회를 도입하여 N+1 관련 쿼리 수를 **4회**로 감소시켰습니다.

문제 해결을 위해 먼저 `Feed` 엔티티의 연관 관계를 분석했습니다.

<img width="1074" height="550" alt="피드 엔티티 연관관계 다이어그램" src="https://github.com/user-attachments/assets/4f3cece6-545e-4832-a103-20a5172d0614" />

`Feed`는 `Student`, `Category`, `University`와 `@ManyToOne` 관계를 맺고, 
`FeedImage`, `FeedLike`, `Bookmark` 등과 `@OneToMany` 관계를 맺고 있었습니다.


## 2. 문제 원인 분석 
쿼리 분석 결과, N+1 문제는 DTO 변환 과정에서 발생하는 다수의 LAZY 로딩과 반복적인 로직 호출로 인해 발생했습니다.

**N+1 유발 지점**

* `@ManyToOne` LAZY 로딩: `feed.getStudent()` 접근 시 N+1 발생.
* `연쇄 LAZY 로딩`: `feed.getStudent().getUniversity()` 접근 시 추가 N+1 발생.
* `@OneToMany` LAZY 로딩: `feed.getImages()` 접근 시 N+1 발생 
*  `좋아요/북마크 여부 확인`: `feedLikeRepository.exists...` 와 `bookmarkRepository.exists...` 를 반복문 내에서 피드마다 호출.


## 3. 최적화 과정

### 3-1. 시도 1: Fetch Join 적용

N+1 문제를 해결하기 위한 첫 번째 시도로 가장 표준적인 방식인 Fetch Join을 선택했습니다. 
`@EntityGraph`를 활용하여 `Feed` 엔티티를 조회할 때 연관된 `Student`와 `FeedImage`까지 한 번에 가져오고자 했습니다. 

하지만 `@OneToMany` 관계인 `FeedImage` 을 Fetch Join에 포함하자마자 
페이지네이션 기능과 충돌하는 예상치 못한 문제에 부딪혔습니다.

Hibernate는 `HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory!`라는 경고 로그를 출력했습니다. 

이는 데이터베이스 레벨에서 `LIMIT` 절을 통해 효율적으로 페이징하는 것이 아니라, 
모든 조회 결과를 애플리케이션 메모리로 가져온 뒤 직접 페이징 처리를 한다는 의미입니다. 

이러한 In-Memory 페이징 방식은 데이터가 많아질수록 심각한 성능 저하와 OOM(Out Of Memory)을 유발할 수 있으므로, 
`FeedImage`를 가져올 때 Fetch Join 전략은 포기해야 했습니다.

### 3-2. 시도 2: Batch Size 적용 

Fetch Join의 대안으로 `@BatchSize`를 적용하는 전략을 시도했습니다. 
`FeedImage` 컬렉션에 `@BatchSize`를 설정하자, N개의 개별 쿼리가 1개의 `IN` 절을 사용하는 쿼리로 성공적으로 통합되었습니다.

하지만 `Student`에서는 동일한 최적화가 적용되지 않았습니다. 
`@BatchSize` 설정에도 불구하고 여전히 `Student` 엔티티를 조회하기 위한 개별 쿼리가 N번 실행되는 현상이 지속되었습니다.

원인 분석 결과, `Student` 엔티티 내부의 다수 연관관계가 문제였습니다. 

`Student` 엔티티는 여러 다른 엔티티와 `@OneToOne` 관계를 맺고 있었으며, 
해당 관계들의 FetchType이 기본값인 `EAGER`로 설정되어 있었습니다.

<img width="1037" height="502" alt="Student 엔티티 연관관계 다이어그램" src="https://github.com/user-attachments/assets/b22ce627-5931-41b2-aec0-64ff1d4eca22" />

Hibernate가 `Student` 프록시를 배치로 초기화하는 과정에서 이 Eager Loading 설정들이 연쇄적으로 동작하면서 충돌이 발생했고, 
결과적으로 배치 처리가 실패하여 개별 쿼리로 폴백(Fallback)되는 것으로 확인되었습니다.

### 3-3. 시도 3: DTO 프로젝션 적용

`Student` 엔티티는 `@OneToOne` 관계에서 연관 관계의 주인이 아니도록 설계되었습니다.

이로 인해 FetchType을 LAZY로 명시적으로 변경하더라도 Eager Loading이 강제되는 경향이 있어
엔티티 조회 자체의 복잡성이 높다고 판단했습니다.

따라서 엔티티를 직접 조회하는 대신, 필요한 데이터만 선별하여 DTO로 바로 조회하는 DTO 프로젝션 방식으로 전략을 변경했습니다.

결과적으로 이 방식을 통해 Eager Loading 연쇄 문제를 원천적으로 회피하였고, 
N개의 `Student` 조회 쿼리를 단 1개의 DTO 프로젝션 쿼리로 대체하여 최적화를 완료했습니다.

## 4. N+1 쿼리 수 비교 (페이지 크기 = 10 기준)

| N+1 발생 지점 | Before (개별 조회) | After (최적화 적용) | 최적화 기법 |
| :--- | :---: | :---: | :--- |
| **작성자 정보 (Student + University)** | 20회 (10+10) | **1회** | DTO Projection |
| **좋아요 상태 (Like)** | 10회 | **1회** | Bulk IN Query |
| **북마크 상태 (Bookmark)**| 10회 | **1회** | Bulk IN Query |
| **피드 이미지 (Image)** | 10회 | **1회** | @BatchSize |
| **합계** | **50회** | **4회** |  |
