### PR TITLE
feat: feed 조회 시 university_id, category_id, pinned, created_date 기준 복합 인덱스 추가하여 조회 성능 개선

### DIFF
--- a/src/main/java/com/team/buddyya/feed/repository/FeedRepository.java
+++ b/src/main/java/com/team/buddyya/feed/repository/FeedRepository.java
@@ -4,16 +4,41 @@ import com.team.buddyya.feed.domain.Category;
 import com.team.buddyya.feed.domain.Feed;
 import com.team.buddyya.student.domain.Student;
 import com.team.buddyya.student.domain.University;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
-    Page<Feed> findAllByUniversityAndCategory(University university, Category category, Pageable pageable);
+    @Query("""
+        SELECT f
+        FROM Feed f
+        WHERE f.university = :university
+          AND f.category   = :category
+        ORDER BY f.pinned DESC, f.createdDate DESC
+    """)
+    Page<Feed> findFeedsByUnivAndCategory(@Param("university") University university,
+                                          @Param("category") Category category,
+                                          Pageable pageable);
+
+
+    @Query("""
+        SELECT f
+        FROM Feed f
+        WHERE f.university = :university
+          AND f.category = :category
+        ORDER BY f.likeCount DESC, f.createdDate DESC
+    """)
+    Page<Feed> findPopularFeedsByUnivAndCategory(@Param("university") University university,
+                                                 @Param("category") Category category,
+                                                 Pageable pageable);
 
     Page<Feed> findAllByStudent(Student student, Pageable pageable);
 

--- a/src/main/java/com/team/buddyya/feed/service/FeedService.java
+++ b/src/main/java/com/team/buddyya/feed/service/FeedService.java
@@ -107,10 +107,15 @@ public class FeedService {
         Category category = categoryService.getCategory(request.category());
         Pageable customPageable = PageRequest.of(
                 pageable.getPageNumber(),
-                pageable.getPageSize(),
-                getSortBy(category)
+                pageable.getPageSize()
         );
-        return feedRepository.findAllByUniversityAndCategory(university, category, customPageable);
+        Page<Feed> feeds;
+        if (category.getName().equals("POPULAR")) {
+            feeds = feedRepository.findPopularFeedsByUnivAndCategory(university, category, customPageable);
+        } else {
+            feeds = feedRepository.findFeedsByUnivAndCategory(university, category, customPageable);
+        }
+        return feeds;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/db/migration/V32__Add_feed_university_category_pinned_created_index.sql 
+++ b/src/main/resources/db/migration/V32__Add_feed_university_category_pinned_created_index.sql 
@@ -1,0 +1,2 @@
+CREATE INDEX idx_feed_uni_cat_order
+    ON feed (university_id, category_id, pinned DESC, created_date DESC);


### PR DESCRIPTION
## 🛠️ 작업 내용

- **복합 인덱스 추가:** `feed(university_id, category_id, pinned DESC, created_date DESC)`
  - 인덱스명: `idx_feed_uni_cat_order`
  - Flyway 파일: `V32__Add_feed_university_category_pinned_created_index.sql`
  - 목적: 대표 조회에서 **index_merge + filesort 제거** 및 정렬 비용 절감
    ```sql
    SELECT
      f.id, f.title, f.pinned, f.created_date
    FROM feed f
    WHERE f.university_id = ? AND f.category_id = ?
    ORDER BY f.pinned DESC, f.created_date DESC
    LIMIT :size;
    ```

## 📊 성능 측정 결과 (데이터 총 400만 건; 조합당 10만 건)

- **단일 2개 인덱스**(university_id, category_id): 평균 **≈296ms** *(index_merge + filesort)*
- **복합 2컬럼**(uni, cat): 평균 **≈121ms** *(–59.05%)* — 여전히 *filesort 발생*
- **복합 4컬럼**(uni, cat, pinned, created): 평균 **≈13ms** *(–95.61%)* — *filesort 제거* ✅ **선택**

## ⚖️ 트레이드오프

- **쓰기(INSERT) 평균 지연:** 단일 대비 **+0.35ms (≈+29.41%)**
- **인덱스 용량 증가:** (uni,cat) **~130MB →** (uni,cat,pinned,created) **~169.91MB**

> 채택 근거: 해당 API는 **읽기 비중이 압도적**이며, `pinned` 변경 빈도도 낮음.  
> 정렬까지 인덱스로 해결되어 *LIMIT early-out* 가능, 후반 페이지 성능 저하 완화.

## ✅ 결론(의사결정)

트레이드오프(쓰기 지연 증가, 인덱스 용량 증가)를 검토했지만, **조회 성능 개선 효과가 더 효과적이라고 판단**하였습니다.  
- 단일 대비 평균 **≈296ms → ≈13ms (–95.61%)**, `filesort` 제거, 후반 페이지에서도 안정적 성능
- 서비스 특성상 **읽기 비중이 매우 높고**, `pinned`/`created_date` 변경 빈도는 낮아 **쓰기 비용은 수용 가능**

따라서 **4컬럼 복합 인덱스**  
`(university_id, category_id, pinned DESC, created_date DESC)`  
를 적용하였습니다


## ✅ 적용 SQL (Flyway)

```sql
-- V32__Add_feed_university_category_pinned_created_index.sql
CREATE INDEX idx_feed_uni_cat_order
  ON feed (university_id, category_id, pinned DESC, created_date DESC);
```




🔍 검증 방법 (체크리스트)
1) 실행계획 비교
```sql
EXPLAIN ANALYZE
SELECT id, title, pinned, created_date
FROM feed
WHERE university_id = 10 AND category_id = 2
ORDER BY pinned DESC, created_date DESC
LIMIT 1000;
```

```sql
EXPLAIN ANALYZE
SELECT id, title, pinned, created_date
FROM feed IGNORE INDEX (idx_feed_uni_cat_order)
WHERE university_id = 10 AND category_id = 2
ORDER BY pinned DESC, created_date DESC
LIMIT 1000;
```

기대: Using filesort 제거, Index lookup using idx_feed_uni_cat_order

## 🎯리뷰 포인트
- 인덱스 컬럼/순서가 실제 정렬(pinned DESC, created_date DESC)과 동일한지
- 대표 쿼리에서 Using filesort 제거 및 체감 성능 개선 여부
- 쓰기/디스크 비용 증가가 운영 패턴상 수용 가능한지
